### PR TITLE
fix: improve SEO and web crawling configurations

### DIFF
--- a/app/api/robots/route.ts
+++ b/app/api/robots/route.ts
@@ -7,7 +7,7 @@ export async function GET() {
   
   const robotsTxt = `User-agent: *
 Allow: /
-Disallow: /zh/
+Disallow: /zh-cn/
 Disallow: /en/
 
 Host: ${host}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -4,6 +4,16 @@ import { source } from '@/lib/source';
 
 export const revalidate = false;
 
+// Function to escape special characters in URLs
+const escapeXmlChars = (url: string): string => {
+  return url
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+};
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const url = (path: string): string => new URL(path, domain).toString();
 
@@ -25,8 +35,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       },
     ...(await Promise.all(
       source.getPages().map(async (page) => {
+        // Escape special characters in URL
+        const escapedUrl = escapeXmlChars(url(page.url));
         return {
-          url: url(page.url),
+          url: escapedUrl,
           changeFrequency: 'weekly',
           priority: 0.5,
         } as MetadataRoute.Sitemap[number];

--- a/middleware.ts
+++ b/middleware.ts
@@ -13,7 +13,7 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
   }
 
   if (pathname === '/robots.txt') {
-    return NextResponse.redirect(new URL('/api/robots', request.url));
+    return NextResponse.rewrite(new URL('/api/robots', request.url));
   }
 
   const i18nMiddleware = createI18nMiddleware(i18n);
@@ -24,6 +24,6 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
 
 export const config = {
   matcher: [
-    '/((?!api|_next/static|_next/image|images/|icons/|favicon/|favicon.ico|logo.svg|robots.txt|sitemap.xml).*)/',
+    '/((?!api|_next/static|_next/image|images/|icons/|favicon/|favicon.ico|logo.svg|sitemap.xml).*)/',
   ],
 };


### PR DESCRIPTION
- Update robots.txt to disallow crawling of /zh-cn/ instead of /zh/
- Add XML character escaping for sitemap URLs to ensure proper XML format
- Change robots.txt handling from redirect to rewrite for better performance
- Update middleware matcher configuration to correctly handle robots.txt