### PR TITLE
feat: add localized banner with styled CTA button to docs

### DIFF
--- a/app/[lang]/docs/layout.tsx
+++ b/app/[lang]/docs/layout.tsx
@@ -2,7 +2,10 @@ import { baseOptions } from '@/app/layout.config';
 import { getLanguageSlug } from '@/lib/i18n';
 import { source } from '@/lib/source';
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
+import { Banner } from 'fumadocs-ui/components/banner';
 import type { ReactNode } from 'react';
+import Link from 'next/link';
+import styles from '@/app/components/banner-button.module.css';
 
 export default function Layout({
   children,
@@ -13,12 +16,27 @@ export default function Layout({
 }) {
   const tree = source.pageTree[params.lang];
 
+  // Only render banner for Chinese language
+  const showBanner = params.lang === 'zh-cn';
+
   return (
-    <DocsLayout
-      tree={tree}
-      {...baseOptions}
-      nav={{ ...baseOptions.nav, url: getLanguageSlug(params.lang) + '/' }}
-    >
+    <>
+      {showBanner && (
+        <Banner id="docs-banner" variant="rainbow">
+          🎉 Sealos 首充折扣，限时返场！最高立返 10000，活动日期 4月22日-4月28日
+          <Link href="https://cloud.sealos.run" className={styles.button}>
+            <span className={styles.buttonText}>查看详情</span>
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none">
+              <path fillRule="evenodd" clipRule="evenodd" d="M7.75419 3.08752C7.52638 3.31532 7.52638 3.68467 7.75419 3.91248L10.2584 6.41666H2.33333C2.01117 6.41666 1.75 6.67783 1.75 7C1.75 7.32216 2.01117 7.58333 2.33333 7.58333H10.2584L7.75419 10.0875C7.52638 10.3153 7.52638 10.6847 7.75419 10.9125C7.98199 11.1403 8.35134 11.1403 8.57915 10.9125L12.0791 7.41248C12.307 7.18467 12.307 6.81532 12.0791 6.58752L8.57915 3.08752C8.35134 2.85971 7.98199 2.85971 7.75419 3.08752Z" fill="white"></path>
+            </svg>
+          </Link>
+        </Banner>
+      )}
+      <DocsLayout
+        tree={tree}
+        {...baseOptions}
+        nav={{ ...baseOptions.nav, url: getLanguageSlug(params.lang) + '/' }}
+      >
       <span
         className="absolute inset-0 z-[-1] h-[64rem] max-h-screen overflow-hidden"
         style={{
@@ -114,5 +132,6 @@ export default function Layout({
       </span>
       {children}
     </DocsLayout>
+    </>
   );
 }

--- a/app/components/banner-button.module.css
+++ b/app/components/banner-button.module.css
@@ -1,0 +1,18 @@
+.button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 20px;
+  padding-inline: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  border-radius: 52px;
+  background: linear-gradient(90deg, rgb(16, 88, 255) 0%, rgb(131, 138, 241) 57.5%, rgb(255, 128, 230) 100%);
+  cursor: pointer;
+}
+
+.buttonText {
+  color: white;
+  margin-right: 6px;
+  font-size: 14px;
+}


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Added a localized promotional banner with a styled CTA button that appears only for Chinese language users in the documentation section.

- Modified `app/[lang]/docs/layout.tsx` to conditionally render a promotional banner for Chinese users with a time-limited discount offer.
- Created `app/components/banner-button.module.css` to style the call-to-action button with a gradient background and proper spacing.
- Implemented language-specific conditional logic to ensure the banner only appears for Chinese language users (`zh-cn`).

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->