### PR TITLE
ci: Add GitHub Actions workflow to automate documentation updates for latest version

### DIFF
--- a/.github/workflows/latest-version.yml
+++ b/.github/workflows/latest-version.yml
@@ -1,0 +1,31 @@
+name: 🤖Using latest version to fix docs
+on:
+  push:
+    branches:
+      - main
+jobs:
+  latest-docs:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Use command to generate version
+        run: |
+          bash scripts/latest_version.sh
+      - uses: peter-evans/create-pull-request@v5
+        if: "steps.tagpr.outputs.version != ''"
+        with:
+          title: 'Release sealos docs for latest version'
+          body: |
+            
+            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
+          commit-message: |
+            🤖 New release for sealos docs using robot.
+          branch: docs-robot-latest
+          draft: true
+          signoff: true
+          delete-branch: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>

--- a/scripts/latest_version.sh
+++ b/scripts/latest_version.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright © 2022 sealos.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+fetchURL="https://raw.githubusercontent.com/labring/sealos/refs/heads/main/.tagpr.json"
+
+PRE_VERSION=$(curl -s ${fetchURL} | jq -r '".pre-version"')
+TAG=$(curl -s ${fetchURL} | jq -r '.version')
+
+## check version is release version
+if [[ ${TAG} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "!!!!! is release version, will update docs"
+    sed -i "s#${PRE_VERSION}#${TAG}#g" content/docs/self-hosting/install.zh-cn.mdx
+else
+    echo "!!!!! is not release version, will skip update docs"
+fi


### PR DESCRIPTION
This pull request introduces automation to update documentation with the latest release version. It adds a GitHub Actions workflow and a supporting script to check for new release versions and update documentation accordingly.

**Automation for documentation updates:**

* Added a new workflow file `.github/workflows/latest-version.yml` to automatically check for the latest version on pushes to the `main` branch and create a pull request to update documentation when a new release version is detected.
* Introduced the `scripts/latest_version.sh` script, which fetches the latest version information from `.tagpr.json`, verifies if it is a release version, and updates the version in `content/docs/self-hosting/install.zh-cn.mdx` if appropriate.