### PR TITLE
docs: Update Sealos version compatibility for Kubernetes v1.30.0

### DIFF
--- a/content/docs/k8s/quick-start/deploy-kubernetes.zh-cn.mdx
+++ b/content/docs/k8s/quick-start/deploy-kubernetes.zh-cn.mdx
@@ -159,6 +159,7 @@ $ sealos run kubernetes.tar # 单机安装，集群安装同理
 | `>=1.26` | `>=v4.1.4-rc3`    | v1       | labring/kubernetes:v1.26.0 |
 | `>=1.27` | `>=v4.2.0-alpha3` | v1       | labring/kubernetes:v1.27.0 |
 | `>=1.28` | `>=v5.0.0`        | v1       | labring/kubernetes:v1.28.0 |
+| `>=1.30` | `>=v5.1.0`        | v1       | labring/kubernetes:v1.30.0 |
 
 根据 Kubernetes 版本的不同，您可以选择不同的 Sealos 版本和 CRI 版本。例如，如果您要使用 Kubernetes v1.26.0 版本，您可以选择 sealos v4.1.4-rc3 及更高版本，并使用 v1 CRI 版本。
 
@@ -173,7 +174,7 @@ $ sealos run kubernetes.tar # 单机安装，集群安装同理
 | `>=1.26` | `>=v4.1.4-rc3`    | v1       | labring/kubernetes-docker:v1.26.0 |
 | `>=1.27` | `>=v4.2.0-alpha3` | v1       | labring/kubernetes-docker:v1.27.0 |
 | `>=1.28` | `>=v5.0.0`        | v1       | labring/kubernetes-docker:v1.28.0 |
-
+| `>=1.30` | `>=v5.1.0`        | v1       | labring/kubernetes-docker:v1.30.0 |
 
 与支持 Containerd 的 Kubernetes 镜像类似，您可以根据 Kubernetes 版本的不同选择不同的 Sealos 版本和 CRI 版本。例如，如果您要使用 Kubernetes v1.26.0 版本，您可以选择 sealos v4.1.4-rc3 及更高版本，并使用 v1 CRI 版本。
 


### PR DESCRIPTION
This pull request updates the Kubernetes version compatibility tables in the Chinese quick-start deployment documentation to include support for Kubernetes v1.30. The new entries specify the required Sealos and CRI versions for this Kubernetes release.

**Documentation updates for Kubernetes v1.30:**

* Added a new row for Kubernetes v1.30 to the Containerd compatibility table in `deploy-kubernetes.zh-cn.mdx`, specifying Sealos version `>=v5.1.0` and the corresponding image `labring/kubernetes:v1.30.0`.
* Added a new row for Kubernetes v1.30 to the Docker compatibility table in `deploy-kubernetes.zh-cn.mdx`, specifying Sealos version `>=v5.1.0` and the corresponding image `labring/kubernetes-docker:v1.30.0`.