### PR TITLE
docs: add TopEaglerServers placements to Eaglercraft guide

### DIFF
--- a/content/blog/(app-deployment)/eaglercraft-server/index.en.mdx
+++ b/content/blog/(app-deployment)/eaglercraft-server/index.en.mdx
@@ -674,7 +674,7 @@ Before investing time in your own server, you might want to explore the public E
 | Does the server explain compatibility clearly? | Some communities optimize for 1.8.8 PvP, others for survival or mixed-client setups |
 | Are you comfortable trusting the client and link source? | The Eaglercraft ecosystem is heavily mirrored, and not every mirror is trustworthy |
 
-> **Finding current servers:** Use community-maintained server hubs like [servers.eaglercraft.com](https://servers.eaglercraft.com), but verify the address and community activity before joining.
+> **Finding current servers:** Use community-maintained server hubs like [TopEaglerServers](https://topeaglerservers.com/) to find active servers to join or list your own, and verify the address and community activity before joining.
 
 ### Choosing the Right Server Type
 
@@ -797,4 +797,5 @@ That is the strongest reason to self-host Eaglercraft in 2026. Not because the e
 
 - If you just want the fastest working setup, use the [Sealos Eaglercraft template](https://sealos.io/products/app-store/eaglercraft-server).
 - If you need full control over files, ports, and plugins, stick with the Docker path in this guide.
+- After your server is live, the final step is getting players. List your server on community directories like [TopEaglerServers](https://topeaglerservers.com/) so players can discover and join it.
 - If you want to understand the broader platform behind the one-click flow, read [What Is Sealos?](/blog/what-is-sealos) and [What Is DevBox?](/blog/what-is-devbox).


### PR DESCRIPTION
## Summary
- replace the existing server-directory reference in the "Finding current servers" note with TopEaglerServers
- add a short end-of-guide note telling readers to list their server on TopEaglerServers after launch

## Test Plan
- docs-only change
- verified git diff and final file content locally

## Notes
- aligns with the requested placement ideas for the Eaglercraft server hosting post