### PR TITLE
fix(deploy): update Cloudflare preview and routing config

### DIFF
--- a/.github/workflows/preview-cloudflare.yml
+++ b/.github/workflows/preview-cloudflare.yml
@@ -52,25 +52,6 @@ jobs:
           npm ci
           npm run build
 
-      - name: Validate Cloudflare credentials
-        run: |
-          if [ -z "$CF_API_TOKEN" ]; then
-            echo "::error::Missing Cloudflare API token. Set secrets.CLOUDFLARE_API_TOKEN (or secrets.CF_API_TOKEN)."
-            exit 1
-          fi
-          if [ -z "$CF_ACCOUNT_ID" ]; then
-            echo "::error::Missing Cloudflare account ID. Set secrets.CLOUDFLARE_ACCOUNT_ID or vars.CLOUDFLARE_ACCOUNT_ID."
-            exit 1
-          fi
-          RESP="$(curl -sS -X GET 'https://api.cloudflare.com/client/v4/user/tokens/verify' \
-            -H "Authorization: Bearer $CF_API_TOKEN" \
-            -H 'Content-Type: application/json')"
-          echo "$RESP" | grep -q '"success":true' || {
-            echo "::error::Cloudflare token verification failed. Ensure token is valid and has Pages deploy permissions."
-            echo "$RESP"
-            exit 1
-          }
-
       - name: Deploy to Cloudflare Pages
         id: deploy
         uses: cloudflare/wrangler-action@v3

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,5 @@
+/mtc.js
+  Cache-Control: public, max-age=31536000, immutable
+
+/api/script.js
+  Cache-Control: public, max-age=31536000, immutable

--- a/public/_redirects
+++ b/public/_redirects
@@ -23,6 +23,20 @@ https://sealos.run/en/* https://sealos.io/:splat 302
 /robots.txt /api/robots 200
 
 # Legacy redirects
+/zh-Hans/blog https://sealos.run/blog 308
+/zh-Hans/blog/ https://sealos.run/blog/ 308
+/zh-Hans/blog/* https://sealos.run/blog/:splat 308
+/docs/Intro https://sealos.io/docs/overview/intro 308
+/docs/5.0.0/Intro https://sealos.io/docs/overview/intro 308
+/zh-Hans https://sealos.run 308
+/zh-Hans/ https://sealos.run/ 308
+/zh-Hans/* https://sealos.run/:splat 308
+/self-hosting https://sealos.run/self-hosting 308
+/docs/5.0.0/user-guide/ai-proxy https://sealos.run/docs/5.0.0/user-guide/ai-proxy/ 308
+/docs/5.0.0/developer-guide/sealos/installation https://sealos.run/docs/5.0.0/developer-guide/sealos/installation 308
+/docs/self-hosting/sealos/installation https://sealos.run/docs/self-hosting/sealos/installation 308
+/docs/self-hosting/lifecycle-management/quick-start/deploy-kubernetes https://sealos.run/docs/self-hosting/lifecycle-management/quick-start/deploy-kubernetes 308
+/company https://sealos.run/company 308
 /devbox /products/devbox 301
 /devbox/ /products/devbox/ 301
 /education /solutions/industries/education 301


### PR DESCRIPTION
## Summary
- remove the stale manual Cloudflare token verification from the Cloudflare PR preview workflow
- rely on wrangler-action for Cloudflare authentication, matching the production deploy workflow
- add legacy redirects and long-lived cache headers for static scripts

## Verification
- ruby YAML parse for .github/workflows/preview-cloudflare.yml
- npx prettier --check .github/workflows/preview-cloudflare.yml
- git diff --check -- .github/workflows/preview-cloudflare.yml

## Notes
- npm run lint was attempted earlier and fails on existing TypeScript/static asset errors unrelated to this workflow change.


## Vercel rule migration parity
- Migrated all 10 `vercel.json` redirects into `public/_redirects`.
- Migrated both `vercel.json` cache header rules into `public/_headers`.
- Verified the current PR diff includes `public/_redirects` and `public/_headers`, with no missing Vercel redirect/header rules.
