### PR TITLE
feat(devbox): redesign product page to match homepage

### DIFF
--- a/app/[lang]/products/devbox/components/footerCta.tsx
+++ b/app/[lang]/products/devbox/components/footerCta.tsx
@@ -1,26 +1,28 @@
 import { AnimateElement } from '@/components/ui/animated-wrapper';
-import { CallToActionSection } from '@/components/ui/call-to-action-section';
 import { appDomain } from '@/config/site';
 import { languagesType } from '@/lib/i18n';
 
-export default function Example({
-  lang = 'en',
-}: {
-  lang?: languagesType;
-}) {
+export default function FooterCta({ lang = 'en' }: { lang?: languagesType }) {
   const buttonText =
     lang === 'zh-cn' ? '免费开始（无需信用卡）' : 'Start Free – No Credit Card';
   const buttonHref = `${appDomain}/?openapp=system-devbox`;
   return (
-    <div className="mt-[140px]">
+    <div className="pt-8 sm:pt-12">
       <AnimateElement type="slideUp">
-        <CallToActionSection
-          title="Develop faster and deploy smarter with DevBox"
-          buttonText={buttonText}
-          buttonHref={buttonHref}
-          newWindow={false}
-          className=""
-        />
+        <section className="inset-shadow-bubble relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.04] px-5 py-12 text-center backdrop-blur sm:px-8 sm:py-16">
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-linear-to-r from-transparent via-blue-400/60 to-transparent" />
+          <div className="mx-auto max-w-3xl">
+            <h2 className="text-3xl leading-tight font-medium text-white sm:text-5xl">
+              Develop faster and deploy smarter with DevBox
+            </h2>
+            <a
+              href={buttonHref}
+              className="mt-8 inline-flex h-12 w-full items-center justify-center rounded-full border border-white bg-white px-7 text-base font-medium text-zinc-950 transition-colors hover:bg-zinc-200 sm:w-auto"
+            >
+              {buttonText}
+            </a>
+          </div>
+        </section>
       </AnimateElement>
     </div>
   );

--- a/app/[lang]/products/devbox/components/metrics-visualization.tsx
+++ b/app/[lang]/products/devbox/components/metrics-visualization.tsx
@@ -213,27 +213,26 @@ export default function MetricsVisualization({
   }, []);
 
   const colorClasses = {
-    blue: 'from-blue-500 to-indigo-600 text-blue-600 bg-blue-100',
-    green: 'from-green-500 to-emerald-600 text-green-600 bg-green-100',
-    purple: 'from-purple-500 to-pink-600 text-purple-600 bg-purple-100',
-    emerald: 'from-emerald-500 to-teal-600 text-emerald-600 bg-emerald-100',
+    blue: 'from-blue-500 to-indigo-600 text-blue-300 bg-blue-500/10',
+    green: 'from-green-500 to-emerald-600 text-green-300 bg-green-500/10',
+    purple: 'from-purple-500 to-pink-600 text-purple-300 bg-purple-500/10',
+    emerald: 'from-emerald-500 to-teal-600 text-emerald-300 bg-emerald-500/10',
   };
 
   return (
-    <section className="bg-gradient-to-b py-12 sm:py-16 lg:py-20">
+    <section className="py-4 sm:py-8">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <AnimateElement type="slideUp">
           <div className="mb-12 text-center sm:mb-16">
-            <h2 className="mb-3 text-3xl font-bold text-gray-900 sm:mb-4 sm:text-4xl md:text-5xl">
+            <h2 className="mb-3 text-3xl font-medium text-white sm:mb-4 sm:text-4xl md:text-5xl">
               {t.title}
             </h2>
-            <p className="mx-auto max-w-3xl px-4 text-lg text-gray-600 sm:px-0 sm:text-xl">
+            <p className="mx-auto max-w-3xl px-4 text-base leading-7 text-zinc-400 sm:px-0 sm:text-xl">
               {t.subtitle}
             </p>
           </div>
         </AnimateElement>
 
-        {/* Key Metrics Grid */}
         <div className="mb-12 grid grid-cols-1 gap-6 sm:mb-16 sm:grid-cols-2 sm:gap-8 lg:mb-20 lg:grid-cols-4">
           {t.metrics.map((metric, index) => {
             const Icon = metric.icon;
@@ -251,7 +250,7 @@ export default function MetricsVisualization({
             return (
               <AnimateElement key={index} type="slideUp" delay={index * 0.1}>
                 <MagicCard
-                  className="relative h-full rounded-xl border-0 bg-white shadow-xl transition-all hover:-translate-y-2 hover:shadow-2xl"
+                  className="inset-shadow-bubble relative h-full rounded-2xl border border-white/10 bg-white/[0.04] backdrop-blur transition-all hover:-translate-y-1 hover:border-blue-400/40"
                   gradientSize={250}
                   gradientColor={gradient.from}
                   gradientOpacity={0.15}
@@ -259,10 +258,9 @@ export default function MetricsVisualization({
                   gradientTo={gradient.to}
                 >
                   <div className="p-6 sm:p-8">
-                    {/* Icon */}
                     <div
                       className={cn(
-                        'mb-3 inline-flex rounded-lg p-2.5 sm:mb-4 sm:p-3',
+                        'mb-3 inline-flex rounded-xl border border-white/10 p-2.5 sm:mb-4 sm:p-3',
                         colors.split(' ')[3],
                       )}
                     >
@@ -274,23 +272,20 @@ export default function MetricsVisualization({
                       />
                     </div>
 
-                    {/* Animated Value */}
                     <div className="mb-2 flex items-baseline">
-                      <span className="text-3xl font-bold text-gray-900 sm:text-4xl">
+                      <span className="text-3xl font-bold text-white sm:text-4xl">
                         {isVisible && <AnimatedNumber value={metric.value} />}
                       </span>
-                      <span className="ml-1 text-xl font-semibold text-gray-700 sm:text-2xl">
+                      <span className="ml-1 text-xl font-semibold text-zinc-300 sm:text-2xl">
                         {metric.unit}
                       </span>
                     </div>
 
-                    {/* Label */}
-                    <div className="mb-1 text-sm font-semibold text-gray-900 sm:text-base">
+                    <div className="mb-1 text-sm font-semibold text-white sm:text-base">
                       {metric.label}
                     </div>
 
-                    {/* Description */}
-                    <div className="text-xs text-gray-600 sm:text-sm">
+                    <div className="text-xs text-zinc-500 sm:text-sm">
                       {metric.description}
                     </div>
                   </div>
@@ -308,25 +303,24 @@ export default function MetricsVisualization({
           })}
         </div>
 
-        {/* Detailed Comparison Table */}
         <AnimateElement type="slideUp">
           <MagicCard
-            className="border-0 bg-white p-4 shadow-xl sm:p-6 lg:p-8"
+            className="inset-shadow-bubble rounded-2xl border border-white/10 bg-white/[0.04] p-4 backdrop-blur sm:p-6 lg:p-8"
             gradientSize={300}
             gradientColor="#3b82f6"
             gradientOpacity={0.1}
             gradientFrom="#3b82f6"
             gradientTo="#10b981"
           >
-            <h3 className="mb-6 text-center text-xl font-bold text-gray-900 sm:mb-8 sm:text-2xl">
+            <h3 className="mb-6 text-center text-xl font-semibold text-white sm:mb-8 sm:text-2xl">
               {t.comparison.title}
             </h3>
 
             <div className="overflow-x-auto">
               <table className="w-full">
                 <thead>
-                  <tr className="border-b-2 border-gray-200">
-                    <th className="px-2 py-2 text-left text-xs font-semibold text-gray-900 sm:px-3 sm:py-3 sm:text-sm lg:px-4">
+                  <tr className="border-b border-white/10">
+                    <th className="px-2 py-2 text-left text-xs font-semibold text-white sm:px-3 sm:py-3 sm:text-sm lg:px-4">
                       Metric
                     </th>
                     <th className="px-2 py-2 text-center text-xs font-semibold text-red-600 sm:px-3 sm:py-3 sm:text-sm lg:px-4">
@@ -344,23 +338,23 @@ export default function MetricsVisualization({
                   {t.comparison.items.map((item, index) => (
                     <tr
                       key={index}
-                      className="group border-b border-gray-100 transition-all hover:bg-gradient-to-r hover:from-blue-50/50 hover:to-green-50/50"
+                      className="group border-b border-white/10 transition-all hover:bg-white/[0.03]"
                     >
-                      <td className="px-2 py-3 text-xs font-medium text-gray-900 sm:px-3 sm:py-4 sm:text-sm lg:px-4">
+                      <td className="px-2 py-3 text-xs font-medium text-white sm:px-3 sm:py-4 sm:text-sm lg:px-4">
                         {item.metric}
                       </td>
-                      <td className="px-2 py-3 text-center text-gray-600 sm:px-3 sm:py-4 lg:px-4">
-                        <span className="inline-block rounded-lg bg-red-50 px-2 py-0.5 text-xs transition-all group-hover:bg-red-100 sm:px-3 sm:py-1 sm:text-sm">
+                      <td className="px-2 py-3 text-center text-zinc-400 sm:px-3 sm:py-4 lg:px-4">
+                        <span className="inline-block rounded-lg border border-red-400/20 bg-red-500/10 px-2 py-0.5 text-xs transition-all sm:px-3 sm:py-1 sm:text-sm">
                           {item.traditional}
                         </span>
                       </td>
-                      <td className="px-2 py-3 text-center text-gray-600 sm:px-3 sm:py-4 lg:px-4">
-                        <span className="inline-block rounded-lg bg-green-50 px-2 py-0.5 text-xs font-medium transition-all group-hover:bg-green-100 sm:px-3 sm:py-1 sm:text-sm">
+                      <td className="px-2 py-3 text-center text-zinc-400 sm:px-3 sm:py-4 lg:px-4">
+                        <span className="inline-block rounded-lg border border-emerald-400/20 bg-emerald-500/10 px-2 py-0.5 text-xs font-medium transition-all sm:px-3 sm:py-1 sm:text-sm">
                           {item.devbox}
                         </span>
                       </td>
                       <td className="hidden px-2 py-3 text-center sm:table-cell sm:px-3 sm:py-4 lg:px-4">
-                        <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-semibold text-blue-800 transition-all group-hover:scale-105 group-hover:bg-blue-200 sm:px-3 sm:py-1 sm:text-sm">
+                        <span className="inline-flex items-center gap-1 rounded-full border border-blue-400/20 bg-blue-500/10 px-2 py-0.5 text-xs font-semibold text-blue-200 transition-all group-hover:scale-105 sm:px-3 sm:py-1 sm:text-sm">
                           <Zap className="h-3 w-3" />
                           {item.improvement}
                         </span>
@@ -371,33 +365,31 @@ export default function MetricsVisualization({
               </table>
             </div>
 
-            {/* Visual Progress Bars */}
             <div className="mt-6 grid grid-cols-1 gap-3 sm:mt-8 sm:grid-cols-2 sm:gap-4">
-              <div className="relative rounded-lg bg-gradient-to-r from-red-50 to-orange-50 p-3 sm:p-4">
-                <div className="mb-1.5 text-xs font-semibold text-gray-700 sm:mb-2 sm:text-sm">
+              <div className="relative rounded-xl border border-red-400/20 bg-red-500/10 p-3 sm:p-4">
+                <div className="mb-1.5 text-xs font-semibold text-zinc-300 sm:mb-2 sm:text-sm">
                   Traditional Development Efficiency
                 </div>
-                <div className="h-3 overflow-hidden rounded-full bg-white sm:h-4">
+                <div className="h-3 overflow-hidden rounded-full bg-black/40 sm:h-4">
                   <div
                     className="h-full rounded-full bg-gradient-to-r from-red-400 to-orange-400 transition-all duration-1000"
                     style={{ width: isVisible ? '30%' : '0%' }}
                   />
                 </div>
-                <div className="mt-1 text-xs text-gray-600">30% efficiency</div>
+                <div className="mt-1 text-xs text-zinc-500">30% efficiency</div>
               </div>
 
-              <div className="relative rounded-lg bg-gradient-to-r from-green-50 to-emerald-50 p-3 sm:p-4">
-                <div className="mb-1.5 text-xs font-semibold text-gray-700 sm:mb-2 sm:text-sm">
+              <div className="relative rounded-xl border border-emerald-400/20 bg-emerald-500/10 p-3 sm:p-4">
+                <div className="mb-1.5 text-xs font-semibold text-zinc-300 sm:mb-2 sm:text-sm">
                   DevBox Development Efficiency
                 </div>
                 <div className="relative">
-                  <div className="h-3 overflow-hidden rounded-full bg-white sm:h-4">
+                  <div className="h-3 overflow-hidden rounded-full bg-black/40 sm:h-4">
                     <div
                       className="h-full rounded-full bg-gradient-to-r from-green-400 to-emerald-400 transition-all duration-1000"
                       style={{ width: isVisible ? '95%' : '0%' }}
                     />
                   </div>
-                  {/* Add animated glow effect for DevBox efficiency - outside progress bar */}
                   {isVisible && (
                     <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-full">
                       <BorderBeam
@@ -411,7 +403,7 @@ export default function MetricsVisualization({
                     </div>
                   )}
                 </div>
-                <div className="mt-1 text-xs text-gray-600">95% efficiency</div>
+                <div className="mt-1 text-xs text-zinc-500">95% efficiency</div>
               </div>
             </div>
           </MagicCard>

--- a/app/[lang]/products/devbox/components/positioning-strip.tsx
+++ b/app/[lang]/products/devbox/components/positioning-strip.tsx
@@ -19,18 +19,20 @@ export default function PositioningStrip({
   const t = translations[lang as keyof typeof translations] || translations.en;
 
   return (
-    <section className="mt-6 w-full">
-      <div className="relative mx-auto max-w-5xl rounded-xl border border-slate-100 bg-white/90 p-4 shadow-sm">
+    <section className="mt-10 w-full">
+      <div className="inset-shadow-bubble relative mx-auto max-w-5xl rounded-2xl border border-white/10 bg-white/[0.04] p-4 shadow-sm backdrop-blur">
         <div className="flex flex-col items-start gap-3 md:flex-row md:items-center md:justify-between">
           <div className="flex items-center gap-3">
-            <div className="h-5 w-1.5 rounded-full bg-gradient-to-b from-emerald-400 to-teal-500" />
-            <p className="text-sm sm:text-base font-medium text-slate-900">{t.title}</p>
+            <div className="h-5 w-1.5 rounded-full bg-gradient-to-b from-blue-300 to-blue-600" />
+            <p className="text-sm font-medium text-white sm:text-base">
+              {t.title}
+            </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
             {t.points.map((p, i) => (
               <span
                 key={i}
-                className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-700 transition-colors hover:border-emerald-300"
+                className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-zinc-300 transition-colors hover:border-blue-400/60"
               >
                 {p}
               </span>

--- a/app/[lang]/products/devbox/components/problems.tsx
+++ b/app/[lang]/products/devbox/components/problems.tsx
@@ -82,32 +82,38 @@ export default function Problems({ lang }: ProblemsProps) {
   const t = translations[lang] || translations.en;
 
   return (
-    <section className="py-16">
+    <section className="py-4 sm:py-8">
       <AnimateElement type="slideUp">
         <div className="mb-12 text-center">
-          <h2 className="mb-4 text-4xl font-bold text-gray-900">{t.title}</h2>
-          <p className="mx-auto max-w-3xl text-xl text-gray-600">
+          <h2 className="mb-4 text-3xl font-medium text-white sm:text-4xl md:text-5xl">
+            {t.title}
+          </h2>
+          <p className="mx-auto max-w-3xl text-base leading-7 text-zinc-400 sm:text-xl">
             {t.subtitle}
           </p>
         </div>
       </AnimateElement>
 
-      <div className="mx-auto grid max-w-6xl grid-cols-1 gap-8 md:grid-cols-2">
+      <div className="mx-auto grid max-w-6xl grid-cols-1 gap-4 md:grid-cols-2 lg:gap-6">
         {t.problems.map((problem, index) => (
           <AnimateElement key={index} type="slideUp" delay={index * 0.1}>
-            <div className="flex h-full flex-col rounded-lg border border-gray-100 bg-white p-6 shadow-lg transition-shadow hover:shadow-xl">
+            <div className="inset-shadow-bubble flex h-full flex-col rounded-2xl border border-white/10 bg-white/[0.035] p-5 backdrop-blur transition-colors hover:border-blue-400/40 sm:p-6">
               <div className="mb-4 flex items-start gap-4">
-                <div className="flex-shrink-0">{problemIcons[index]}</div>
+                <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/5 text-blue-300">
+                  {problemIcons[index]}
+                </div>
                 <div className="flex-grow">
-                  <h3 className="mb-2 text-xl font-semibold text-gray-900">
+                  <h3 className="mb-2 text-xl font-semibold text-white">
                     {problem.title}
                   </h3>
-                  <p className="text-gray-600">{problem.description}</p>
+                  <p className="leading-7 text-zinc-400">
+                    {problem.description}
+                  </p>
                 </div>
               </div>
 
-              <div className="mt-auto flex justify-center">
-                <div className="inline-flex items-center rounded-full bg-red-50 px-3 py-1 text-sm font-medium text-red-700">
+              <div className="mt-auto flex justify-start">
+                <div className="inline-flex items-center rounded-full border border-red-400/20 bg-red-500/10 px-3 py-1 text-sm font-medium text-red-200">
                   {problem.impact}
                 </div>
               </div>

--- a/app/[lang]/products/devbox/components/social-proof.tsx
+++ b/app/[lang]/products/devbox/components/social-proof.tsx
@@ -69,19 +69,18 @@ export default function SocialProof({ lang = 'en' }: SocialProofProps) {
 
   return (
     <motion.section
-      className="px-4 py-16 sm:px-6 lg:px-8"
+      className="py-4 sm:py-8"
       initial="hidden"
       animate="visible"
       variants={containerVariants}
     >
       <div className="mx-auto max-w-7xl">
-        {/* Customer Logos */}
         <motion.div variants={itemVariants} className="mb-12 text-center">
-          <p className="mb-8 text-sm font-semibold tracking-wider text-slate-500 uppercase">
+          <p className="mb-8 text-sm font-semibold tracking-wider text-zinc-500 uppercase">
             {t.trustedBy}
           </p>
-          <p className="-mt-4 mb-6 text-xs text-slate-500">{t.tagline}</p>
-          <div className="flex flex-wrap items-center justify-center gap-12">
+          <p className="-mt-4 mb-6 text-xs text-zinc-500">{t.tagline}</p>
+          <div className="flex flex-wrap items-center justify-center gap-8 sm:gap-12">
             {logos.map((logo) => (
               <motion.div
                 key={logo.name}
@@ -91,59 +90,52 @@ export default function SocialProof({ lang = 'en' }: SocialProofProps) {
                 <img
                   src={logo.url}
                   alt={logo.name}
-                  className="h-10 w-auto object-contain"
+                  className="h-10 w-auto object-contain brightness-0 invert"
                 />
               </motion.div>
             ))}
           </div>
         </motion.div>
 
-        {/* Stats and Testimonial Grid */}
         <div className="grid items-center gap-8 md:grid-cols-2">
-          {/* Stats Section */}
           <motion.div
             variants={itemVariants}
             className="flex flex-col justify-center gap-6 sm:flex-row md:justify-start"
           >
-            {/* GitHub Stars */}
             <motion.div
-              className="flex items-center gap-3 rounded-xl border border-gray-100 bg-white px-6 py-4 shadow-lg"
+              className="inset-shadow-bubble flex items-center gap-3 rounded-2xl border border-white/10 bg-white/[0.04] px-6 py-4 backdrop-blur"
               whileHover={{
                 scale: 1.02,
-                boxShadow: '0 20px 25px -5px rgba(0, 0, 0, 0.1)',
               }}
             >
               <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-gradient-to-br from-emerald-500 to-teal-600 shadow-lg shadow-emerald-500/25">
                 <GitBranch className="h-6 w-6 text-white" />
               </div>
               <div>
-                <p className="text-2xl font-bold text-gray-900">16K+</p>
-                <p className="text-sm text-gray-600">{t.githubStars}</p>
+                <p className="text-2xl font-bold text-white">16K+</p>
+                <p className="text-sm text-zinc-400">{t.githubStars}</p>
               </div>
             </motion.div>
 
-            {/* Active Developers */}
             <motion.div
-              className="flex items-center gap-3 rounded-xl border border-gray-100 bg-white px-6 py-4 shadow-lg"
+              className="inset-shadow-bubble flex items-center gap-3 rounded-2xl border border-white/10 bg-white/[0.04] px-6 py-4 backdrop-blur"
               whileHover={{
                 scale: 1.02,
-                boxShadow: '0 20px 25px -5px rgba(0, 0, 0, 0.1)',
               }}
             >
               <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-gradient-to-br from-orange-500 to-amber-600 shadow-lg shadow-orange-500/25">
                 <Users className="h-6 w-6 text-white" />
               </div>
               <div>
-                <p className="text-2xl font-bold text-gray-900">10K+</p>
-                <p className="text-sm text-gray-600">{t.developers}</p>
+                <p className="text-2xl font-bold text-white">10K+</p>
+                <p className="text-sm text-zinc-400">{t.developers}</p>
               </div>
             </motion.div>
           </motion.div>
 
-          {/* Testimonial Card */}
           <motion.div
             variants={itemVariants}
-            className="rounded-2xl border border-slate-200 bg-gradient-to-br from-slate-50 to-emerald-50/30 p-8 shadow-xl"
+            className="inset-shadow-bubble rounded-2xl border border-white/10 bg-white/[0.04] p-6 backdrop-blur sm:p-8"
             whileHover={{ scale: 1.01 }}
           >
             <div className="mb-4 flex gap-1">
@@ -158,7 +150,7 @@ export default function SocialProof({ lang = 'en' }: SocialProofProps) {
                 </motion.div>
               ))}
             </div>
-            <blockquote className="mb-4 text-lg leading-relaxed text-slate-700">
+            <blockquote className="mb-4 text-lg leading-relaxed text-zinc-200">
               "{t.testimonialQuote}"
             </blockquote>
             <div className="flex items-center gap-3">
@@ -166,7 +158,7 @@ export default function SocialProof({ lang = 'en' }: SocialProofProps) {
                 SC
               </div>
               <div>
-                <p className="text-sm font-semibold text-slate-800">
+                <p className="text-sm font-semibold text-white">
                   {t.testimonialAuthor}
                 </p>
               </div>

--- a/app/[lang]/products/devbox/components/solutions-v2.tsx
+++ b/app/[lang]/products/devbox/components/solutions-v2.tsx
@@ -301,14 +301,14 @@ export default function Solutions({ lang }: SolutionsProps) {
   const t = translations[lang] || translations.en;
 
   return (
-    <section className="overflow-hidden py-20">
+    <section className="overflow-hidden py-4 sm:py-8">
       <div className="mx-auto max-w-7xl px-4">
         <AnimateElement type="slideUp">
           <div className="mb-16 text-center">
-            <h2 className="mb-4 text-4xl font-bold text-gray-900 md:text-5xl">
+            <h2 className="mb-4 text-3xl font-medium text-white sm:text-4xl md:text-5xl">
               {t.title}
             </h2>
-            <p className="mx-auto max-w-3xl text-xl text-gray-600">
+            <p className="mx-auto max-w-3xl text-base leading-7 text-zinc-400 sm:text-xl">
               {t.subtitle}
             </p>
           </div>
@@ -332,7 +332,7 @@ export default function Solutions({ lang }: SolutionsProps) {
                     <div className="mb-4 flex items-center gap-4">
                       <div
                         className={cn(
-                          'flex h-14 w-14 items-center justify-center rounded-xl bg-gradient-to-br text-white shadow-lg',
+                          'flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br text-white shadow-lg',
                           colorClasses[
                             story.color as keyof typeof colorClasses
                           ],
@@ -340,34 +340,32 @@ export default function Solutions({ lang }: SolutionsProps) {
                       >
                         <Icon size={32} />
                       </div>
-                      <span className="text-sm font-semibold tracking-wider text-gray-500 uppercase">
+                      <span className="text-sm font-semibold tracking-wider text-zinc-500 uppercase">
                         {story.tagline}
                       </span>
                     </div>
-                    <h3 className="mb-4 text-3xl font-bold text-gray-900 md:text-4xl">
+                    <h3 className="mb-4 text-2xl font-semibold text-white sm:text-3xl md:text-4xl">
                       {story.title}
                     </h3>
-                    <p className="mb-4 text-lg leading-relaxed text-gray-600">
+                    <p className="mb-4 text-base leading-8 text-zinc-400 sm:text-lg">
                       {story.story}
                     </p>
-                    <p className="text-lg font-medium text-gray-800">
+                    <p className="text-base font-medium text-zinc-200 sm:text-lg">
                       {story.transformation}
                     </p>
                   </div>
 
-                  {/* Before/After Comparison */}
                   <div className="grid gap-6 md:grid-cols-2">
-                    {/* Before Card */}
                     <MagicCard
-                      className="rounded-2xl"
+                      className="rounded-2xl border border-red-400/20 bg-red-500/[0.03]"
                       gradientColor="rgba(239, 68, 68, 0.1)"
                       gradientFrom="#ef4444"
                       gradientTo="#dc2626"
                     >
-                      <div className="rounded-2xl border-2 border-red-100 bg-red-50 p-6">
+                      <div className="rounded-2xl border border-red-400/20 bg-red-500/[0.06] p-5 backdrop-blur sm:p-6">
                         <div className="mb-4 flex items-center gap-3">
                           <XIcon className="h-6 w-6 text-red-500" size={24} />
-                          <h4 className="text-xl font-semibold text-gray-900">
+                          <h4 className="text-xl font-semibold text-white">
                             {story.before.title}
                           </h4>
                         </div>
@@ -375,36 +373,35 @@ export default function Solutions({ lang }: SolutionsProps) {
                           {story.before.items.map((item, idx) => (
                             <li key={idx} className="flex items-start gap-3">
                               <span className="mt-1.5 block h-2 w-2 rounded-full bg-red-400" />
-                              <span className="text-gray-700">{item}</span>
+                              <span className="text-zinc-300">{item}</span>
                             </li>
                           ))}
                         </ul>
-                        <div className="rounded-lg bg-white p-4 text-center">
+                        <div className="rounded-xl border border-red-400/20 bg-black/30 p-4 text-center">
                           <div className="text-3xl font-bold text-red-600">
                             {story.before.metric}
                           </div>
-                          <div className="text-sm text-gray-600">
+                          <div className="text-sm text-zinc-400">
                             {story.before.metricLabel}
                           </div>
                         </div>
                       </div>
                     </MagicCard>
 
-                    {/* After Card */}
                     <div className="relative">
                       <MagicCard
-                        className="overflow-hidden rounded-2xl"
+                        className="overflow-hidden rounded-2xl border border-emerald-400/20 bg-emerald-500/[0.03]"
                         gradientColor="rgba(34, 197, 94, 0.1)"
                         gradientFrom="#22c55e"
                         gradientTo="#16a34a"
                       >
-                        <div className="relative rounded-2xl border-2 border-green-100 bg-green-50 p-6">
+                        <div className="relative rounded-2xl border border-emerald-400/20 bg-emerald-500/[0.06] p-5 backdrop-blur sm:p-6">
                           <div className="mb-4 flex items-center gap-3">
                             <CircleCheckIcon
                               className="h-6 w-6 text-green-500"
                               size={24}
                             />
-                            <h4 className="text-xl font-semibold text-gray-900">
+                            <h4 className="text-xl font-semibold text-white">
                               {story.after.title}
                             </h4>
                           </div>
@@ -412,21 +409,20 @@ export default function Solutions({ lang }: SolutionsProps) {
                             {story.after.items.map((item, idx) => (
                               <li key={idx} className="flex items-start gap-3">
                                 <span className="mt-1.5 block h-2 w-2 rounded-full bg-green-400" />
-                                <span className="text-gray-700">{item}</span>
+                                <span className="text-zinc-300">{item}</span>
                               </li>
                             ))}
                           </ul>
-                          <div className="rounded-lg bg-white p-4 text-center">
+                          <div className="rounded-xl border border-emerald-400/20 bg-black/30 p-4 text-center">
                             <div className="text-3xl font-bold text-green-600">
                               {story.after.metric}
                             </div>
-                            <div className="text-sm text-gray-600">
+                            <div className="text-sm text-zinc-400">
                               {story.after.metricLabel}
                             </div>
                           </div>
                         </div>
                       </MagicCard>
-                      {/* BorderBeam outside of card */}
                       <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-2xl">
                         <BorderBeam
                           size={150}
@@ -440,24 +436,22 @@ export default function Solutions({ lang }: SolutionsProps) {
                     </div>
                   </div>
 
-                  {/* Proof Badge */}
                   <div className="mt-8 flex justify-center">
                     <div className="relative">
-                      <div className="inline-flex items-center gap-4 rounded-full bg-gradient-to-r from-blue-100 to-purple-100 px-6 py-3">
+                      <div className="inline-flex max-w-full flex-wrap items-center justify-center gap-3 rounded-full border border-white/10 bg-white/[0.04] px-5 py-3 backdrop-blur sm:gap-4 sm:px-6">
                         <Zap className="h-5 w-5 text-blue-600" />
                         <div className="flex items-baseline gap-2">
-                          <span className="text-2xl font-bold text-gray-900">
+                          <span className="text-2xl font-bold text-white">
                             {story.proof.metric}
                           </span>
-                          <span className="font-medium text-gray-700">
+                          <span className="font-medium text-zinc-200">
                             {story.proof.label}
                           </span>
                         </div>
-                        <span className="text-sm text-gray-600">
+                        <span className="text-sm text-zinc-500">
                           {story.proof.source}
                         </span>
                       </div>
-                      {/* BorderBeam wrapper with proper overflow */}
                       <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-full">
                         <BorderBeam
                           size={80}

--- a/app/[lang]/products/devbox/components/techgrid.tsx
+++ b/app/[lang]/products/devbox/components/techgrid.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from 'react';
 import { AnimateElement } from '@/components/ui/animated-wrapper';
 import { appDomain } from '@/config/site';
 import { CustomButton } from '@/components/ui/button-custom';
-import { Package } from 'lucide-react';
+import { Package, Star } from 'lucide-react';
 import Image from 'next/image';
 
 interface TechItem {
@@ -432,90 +432,70 @@ export default function TechGrid() {
   return (
     <div>
       <AnimateElement type="slideUp">
-        <div className="mb-6 text-center text-4xl font-bold text-black sm:mb-8">
+        <div className="mb-6 text-center text-3xl font-medium text-white sm:mb-8 sm:text-4xl">
           Comprehensive Development Stack Support
         </div>
 
-        {/* Banner */}
         <div className="mb-8 flex justify-center">
-          <div
-            className="text-custom-secondary-text max-w-[760px] rounded-[46px] border border-solid border-[#ABE1FF] px-4 py-3 text-center text-xs font-medium md:text-sm"
-            style={{
-              background:
-                'linear-gradient(90deg, rgba(170, 229, 255, 0.30) 0%, rgba(170, 229, 255, 0.20) 100%)',
-            }}
-          >
+          <div className="max-w-[760px] rounded-full border border-blue-300/20 bg-blue-500/10 px-4 py-3 text-center text-xs font-medium text-zinc-400 md:text-sm">
             Launch specialized development environments for
-            <span className="px-1 text-[#008AB6]">
+            <span className="px-1 text-blue-300">
               any framework or language.
             </span>
           </div>
         </div>
 
-        {/* Tabs */}
-        <div className="mb-4 flex flex-wrap justify-center gap-4 text-sm font-medium sm:text-base">
-          {Object.keys(tileData).map((tab) => (
-            <button
-              key={tab}
-              className={`cursor-pointer rounded-md px-2 py-1 ${
-                activeTab === tab
-                  ? 'rounded-md bg-[#FAFCFF] text-black'
-                  : 'text-custom-secondary-text hover:bg-[#FAFCFF]/80'
-              }`}
-              style={{
-                boxShadow:
+        <div className="mb-4 overflow-x-auto pb-2">
+          <div className="mx-auto flex w-max min-w-full justify-start gap-2 text-sm font-medium sm:justify-center sm:text-base">
+            {Object.keys(tileData).map((tab) => (
+              <button
+                key={tab}
+                className={`cursor-pointer rounded-full border px-3 py-2 whitespace-nowrap transition-colors ${
                   activeTab === tab
-                    ? '0px 4px 4px 0px rgba(19, 51, 107, 0.05), 0px 0px 1px 0px rgba(19, 51, 107, 0.08)'
-                    : '',
-              }}
-              onClick={() => handleTabChange(tab)}
-            >
-              {tab}
-            </button>
-          ))}
+                    ? 'border-white/20 bg-white text-zinc-950'
+                    : 'border-white/10 bg-white/5 text-zinc-300 hover:bg-white/10'
+                }`}
+                onClick={() => handleTabChange(tab)}
+              >
+                {tab}
+              </button>
+            ))}
+          </div>
         </div>
 
-        {/* Category Description */}
-        <div className="text-custom-secondary-text mb-6 text-center text-sm">
+        <div className="mb-6 text-center text-sm text-zinc-500">
           {tileData[activeTab].description}
         </div>
 
-        {/* Grid */}
-        <div className="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {tileData[activeTab].items.map((tech) => {
             const deployName = tech.name.toLowerCase().replace(/\s+/g, '');
             return (
               <div
                 key={tech.name}
-                className="flex flex-col gap-4 rounded-lg bg-white px-6 py-5"
-                style={{
-                  boxShadow:
-                    '0px 12px 40px -25px rgba(6, 26, 65, 0.20), 0px 0px 1px 0px rgba(19, 51, 107, 0.20)',
-                }}
+                className="inset-shadow-bubble flex min-h-[168px] flex-col gap-4 rounded-2xl border border-white/10 bg-white/[0.04] px-5 py-5 backdrop-blur transition-colors hover:border-blue-400/40"
               >
                 <div className="relative flex gap-4">
-                  <div className="relative flex size-7 items-center justify-center text-4xl lg:size-10">
+                  <div className="relative flex size-10 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/5 p-2 text-4xl">
                     <Image
                       src={tech.icon}
                       alt={tech.name}
                       width={40}
                       height={40}
-                      className="size-7 lg:size-10 object-contain"
+                      className="size-7 object-contain"
                       loading="lazy"
                       sizes="40px"
                     />
                   </div>
                   <div className="flex flex-col justify-center">
-                    <h3 className="text-lg font-medium text-black">
+                    <h3 className="text-lg font-medium text-white">
                       {tech.name}
                     </h3>
-                    <p className="text-custom-secondary-text text-xs">
-                      {tech.language}
-                    </p>
+                    <p className="text-xs text-zinc-500">{tech.language}</p>
                   </div>
-                  <div className="absolute top-0 right-0 -mt-2 flex flex-col items-center gap-2 rounded p-2">
-                    <span className="text-yellow-500">⭐</span>
-                    <span className="text-custom-secondary-text text-xs">
+                  <div className="absolute top-0 right-0 -mt-2 flex flex-col items-center gap-1 rounded p-2">
+                    <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+                    <span className="text-xs text-zinc-500">
                       {tech.githubStars
                         ? tech.githubStars.toLocaleString()
                         : 'Popular'}
@@ -523,10 +503,9 @@ export default function TechGrid() {
                   </div>
                 </div>
 
-                {/* Deploy Button */}
                 <div className="mt-4 flex justify-center">
                   <CustomButton
-                    className="group bg-custom-bg text-custom-primary-text hover:ring-custom-bg focus-visible:ring-ring relative flex h-9 w-full max-w-52 cursor-pointer items-center justify-center gap-2 overflow-hidden rounded-md px-4 py-2 text-sm font-medium whitespace-pre shadow-sm transition-all duration-300 ease-out hover:bg-[#97D9FF] hover:ring-2 hover:ring-offset-2 focus-visible:ring-1 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 md:flex"
+                    className="group relative flex h-10 w-full cursor-pointer items-center justify-center gap-2 overflow-hidden rounded-full border border-white bg-white px-4 py-2 text-sm font-medium whitespace-pre text-zinc-950 shadow-sm transition-all duration-300 ease-out hover:bg-zinc-200 focus-visible:ring-1 focus-visible:ring-white focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 md:flex"
                     title="Deploy DevBox"
                     href={`${deployLink}${deployName}`}
                     location="tech-grid"

--- a/app/[lang]/products/devbox/components/usp-chips.tsx
+++ b/app/[lang]/products/devbox/components/usp-chips.tsx
@@ -20,11 +20,7 @@ const translations = {
   },
 };
 
-export default function USPChips({
-  lang = 'en',
-}: {
-  lang?: languagesType;
-}) {
+export default function USPChips({ lang = 'en' }: { lang?: languagesType }) {
   const t = translations[lang as keyof typeof translations] || translations.en;
 
   return (
@@ -33,9 +29,9 @@ export default function USPChips({
         {t.chips.map(({ label, Icon }, i) => (
           <span
             key={i}
-            className="shrink-0 inline-flex items-center gap-2 rounded-full border border-emerald-200/70 bg-emerald-50/60 px-3 py-1.5 text-xs sm:text-sm font-medium text-slate-800 shadow-sm backdrop-blur-[2px] transition-all hover:border-emerald-400/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/50"
+            className="inline-flex shrink-0 items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-medium text-zinc-200 shadow-sm backdrop-blur transition-all hover:border-blue-400/60 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/50 sm:text-sm"
           >
-            <Icon aria-hidden className="h-4 w-4 text-emerald-600" />
+            <Icon aria-hidden className="h-4 w-4 text-blue-300" />
             {label}
           </span>
         ))}

--- a/app/[lang]/products/devbox/components/workflow-v2.tsx
+++ b/app/[lang]/products/devbox/components/workflow-v2.tsx
@@ -312,15 +312,13 @@ export default function Workflow({ lang }: WorkflowProps) {
   const t = translations[lang] || translations.en;
 
   return (
-    <section className="relative py-20">
-      {/* Background decoration */}
-      <div className="absolute inset-0 rounded-3xl bg-gradient-to-b from-gray-50 to-white" />
-      {/* Gradient border overlay */}
+    <section className="relative py-4 sm:py-8">
+      <div className="absolute inset-0 rounded-3xl bg-white/[0.02]" />
       <div
         className="pointer-events-none absolute inset-0 rounded-3xl"
         style={{
           background:
-            'linear-gradient(to bottom, var(--color-gray-200), var(--color-white))',
+            'linear-gradient(to bottom, rgba(255,255,255,0.14), rgba(20,109,255,0.06))',
           mask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
           maskComposite: 'xor',
           WebkitMask:
@@ -333,19 +331,17 @@ export default function Workflow({ lang }: WorkflowProps) {
       <div className="relative mx-auto max-w-7xl px-4">
         <AnimateElement type="slideUp">
           <div className="mb-16 text-center">
-            <h2 className="mb-4 text-4xl font-bold text-gray-900 md:text-5xl">
+            <h2 className="mb-4 text-3xl font-medium text-white sm:text-4xl md:text-5xl">
               {t.title}
             </h2>
-            <p className="mx-auto max-w-3xl text-xl text-gray-600">
+            <p className="mx-auto max-w-3xl text-base leading-7 text-zinc-400 sm:text-xl">
               {t.subtitle}
             </p>
           </div>
         </AnimateElement>
 
-        {/* Timeline */}
         <div className="relative">
-          {/* Vertical line for desktop */}
-          <div className="absolute top-0 bottom-0 left-1/2 hidden w-0.5 -translate-x-1/2 bg-gradient-to-b from-blue-200 via-purple-200 to-pink-200 lg:block" />
+          <div className="absolute top-0 bottom-0 left-1/2 hidden w-px -translate-x-1/2 bg-gradient-to-b from-blue-400/40 via-white/10 to-blue-400/20 lg:block" />
 
           <div className="space-y-12 lg:space-y-20">
             {t.timeline.map((event, index) => {
@@ -360,7 +356,6 @@ export default function Workflow({ lang }: WorkflowProps) {
                       isEven ? 'lg:flex-row' : 'lg:flex-row-reverse',
                     )}
                   >
-                    {/* Content */}
                     <div
                       className={cn(
                         'flex-1',
@@ -369,51 +364,47 @@ export default function Workflow({ lang }: WorkflowProps) {
                     >
                       <div
                         className={cn(
-                          'relative overflow-hidden rounded-2xl bg-white p-8 shadow-xl',
-                          'border-gray-100 transition-colors hover:border-blue-200',
+                          'inset-shadow-bubble relative overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04] p-5 backdrop-blur sm:p-8',
+                          'transition-colors hover:border-blue-400/40',
                         )}
                       >
-                        {/* Time Badge */}
                         <div
                           className={cn(
                             'mb-4 flex items-center gap-3',
                             isEven ? 'lg:justify-end' : '',
                           )}
                         >
-                          <Clock className="h-5 w-5 text-gray-500" />
-                          <span className="text-sm font-semibold text-gray-500">
+                          <Clock className="h-5 w-5 text-zinc-500" />
+                          <span className="text-sm font-semibold text-zinc-500">
                             {event.time}
                           </span>
                         </div>
 
-                        {/* Title with Icon */}
                         <div
                           className={cn(
                             'mb-4 flex items-center gap-3',
                             isEven ? 'lg:flex-row-reverse lg:justify-end' : '',
                           )}
                         >
-                          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-purple-600 text-white">
+                          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-blue-500 to-blue-700 text-white">
                             <IconComponent size={24} />
                           </div>
-                          <h3 className="text-2xl font-bold text-gray-900">
+                          <h3 className="text-xl font-semibold text-white sm:text-2xl">
                             {event.title}
                           </h3>
                         </div>
 
-                        {/* Description */}
-                        <p className="mb-6 text-lg text-gray-600">
+                        <p className="mb-6 text-base leading-7 text-zinc-400 sm:text-lg">
                           {event.description}
                         </p>
 
-                        {/* Before/After Comparison */}
-                        <div className="mb-6 space-y-3 rounded-lg bg-gray-50 p-4">
+                        <div className="mb-6 space-y-3 rounded-xl border border-white/10 bg-black/30 p-4">
                           <div className="flex items-start gap-3">
                             <span className="mt-1.5 block h-2 w-2 flex-shrink-0 rounded-full bg-red-400" />
                             <div className="flex-1">
                               <p
                                 className={cn(
-                                  'text-sm text-gray-600',
+                                  'text-sm text-zinc-400',
                                   isEven ? 'lg:text-left' : '',
                                 )}
                               >
@@ -432,7 +423,7 @@ export default function Workflow({ lang }: WorkflowProps) {
                             <div className="flex-1">
                               <p
                                 className={cn(
-                                  'text-sm text-gray-600',
+                                  'text-sm text-zinc-400',
                                   isEven ? 'lg:text-left' : '',
                                 )}
                               >
@@ -445,29 +436,27 @@ export default function Workflow({ lang }: WorkflowProps) {
                           </div>
                         </div>
 
-                        {/* Metrics */}
-                        <div className="mb-6 flex items-center justify-center rounded-lg bg-gradient-to-r from-blue-50 to-purple-50 p-4">
+                        <div className="mb-6 flex items-center justify-center rounded-xl border border-blue-400/20 bg-blue-500/10 p-4">
                           <div className="text-center">
                             <div className="flex items-baseline justify-center gap-1">
-                              <span className="text-3xl font-bold text-gray-900">
+                              <span className="text-3xl font-bold text-white">
                                 {event.metrics.value}
                               </span>
-                              <span className="text-lg font-medium text-gray-700">
+                              <span className="text-lg font-medium text-zinc-300">
                                 {event.metrics.unit}
                               </span>
                             </div>
-                            <div className="text-sm text-gray-600">
+                            <div className="text-sm text-zinc-500">
                               {event.metrics.label}
                             </div>
                           </div>
                         </div>
 
-                        {/* Details */}
                         <ul className="space-y-2">
                           {event.details.map((detail, idx) => (
                             <li
                               key={idx}
-                              className="flex items-center gap-2 text-sm text-gray-700"
+                              className="flex items-center gap-2 text-sm text-zinc-300"
                             >
                               <CheckCircle className="h-4 w-4 flex-shrink-0 text-green-500" />
                               <span
@@ -479,7 +468,6 @@ export default function Workflow({ lang }: WorkflowProps) {
                           ))}
                         </ul>
 
-                        {/* Add BorderBeam effect for highlighted cards */}
                         {index === 0 && (
                           <BorderBeam
                             size={200}
@@ -493,9 +481,8 @@ export default function Workflow({ lang }: WorkflowProps) {
                       </div>
                     </div>
 
-                    {/* Timeline dot */}
                     <div className="relative z-10 my-8 lg:absolute lg:top-1/2 lg:left-1/2 lg:my-0 lg:-translate-x-1/2 lg:-translate-y-1/2">
-                      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white shadow-lg ring-4 ring-white">
+                      <div className="flex h-16 w-16 items-center justify-center rounded-full border border-white/10 bg-black shadow-lg ring-4 ring-black/60">
                         <div
                           className={cn(
                             'flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br text-2xl',
@@ -512,7 +499,6 @@ export default function Workflow({ lang }: WorkflowProps) {
                       </div>
                     </div>
 
-                    {/* Spacer for desktop */}
                     <div className="hidden flex-1 lg:block" />
                   </div>
                 </AnimateElement>
@@ -521,9 +507,8 @@ export default function Workflow({ lang }: WorkflowProps) {
           </div>
         </div>
 
-        {/* CTA Section */}
         <AnimateElement type="slideUp" delay={0.8}>
-          <div className="relative mt-20 overflow-hidden rounded-3xl bg-gradient-to-r from-blue-600 to-purple-600 p-12 text-center text-white">
+          <div className="inset-shadow-bubble relative mt-20 overflow-hidden rounded-3xl border border-white/10 bg-white/[0.04] p-6 text-center text-white backdrop-blur sm:p-12">
             <Particles
               className="absolute inset-0"
               quantity={50}
@@ -533,10 +518,14 @@ export default function Workflow({ lang }: WorkflowProps) {
               staticity={60}
             />
             <div className="relative z-10">
-              <h3 className="mb-4 text-3xl font-bold">{t.cta.title}</h3>
-              <p className="mb-8 text-lg opacity-90">{t.cta.subtext}</p>
+              <h3 className="mb-4 text-2xl font-semibold sm:text-3xl">
+                {t.cta.title}
+              </h3>
+              <p className="mb-8 text-base text-zinc-400 sm:text-lg">
+                {t.cta.subtext}
+              </p>
               <CustomButton
-                className="group inline-flex items-center rounded-lg border-2 border-white/70 bg-transparent px-8 py-4 font-semibold text-white transition-all hover:bg-white hover:text-blue-600 hover:shadow-xl"
+                className="group inline-flex h-12 items-center rounded-full border border-white bg-white px-6 font-semibold text-zinc-950 transition-all hover:bg-zinc-200 hover:shadow-xl"
                 title={t.cta.button}
                 href={`${appDomain}/?openapp=system-devbox`}
                 location="workflow-cta"

--- a/app/[lang]/products/devbox/page.tsx
+++ b/app/[lang]/products/devbox/page.tsx
@@ -5,14 +5,18 @@ import MetricsVisualization from './components/metrics-visualization';
 import TechGrid from './components/techgrid';
 import FooterCta from './components/footerCta';
 import SocialProof from './components/social-proof';
-import Footer from '@/components/footer';
-import Header from '@/components/header';
-import Hero from '@/components/header/hero';
+import { Footer } from '@/new-components/Footer';
+import { Header } from '@/new-components/Header';
+import { HeroBackground } from '@/app/[lang]/(home)/(new-home)/components/HeroBackground';
+import { GodRays } from '@/new-components/GodRays';
+import Image from 'next/image';
 import Video from '@/components/video';
+import { Button } from '@/components/ui/button';
 import { generatePageMetadata } from '@/lib/utils/metadata';
 import { appDomain, siteConfig } from '@/config/site';
 import { languagesType } from '@/lib/i18n';
 import placeholderImage from '/public/images/video.webp';
+import BottomLightImage from '@/assets/bottom-light.svg';
 import StructuredDataComponent from '@/components/structured-data';
 import {
   generateDevBoxSchema,
@@ -37,8 +41,7 @@ const translations = {
       main: '使用云端开发环境，交付速度提升10倍',
       sub: '不仅是云 IDE：在一个平台上完成编码、打包与部署。',
     },
-    description:
-      '标准镜像发布，一键部署，IDE 不限，环境 100% 一致。',
+    description: '标准镜像发布，一键部署，IDE 不限，环境 100% 一致。',
     watchDemo: '在线演示 (2分钟)',
   },
 };
@@ -80,63 +83,140 @@ export default function HomePage({
 
   return (
     <>
-      {/* Structured Data for SEO */}
       <StructuredDataComponent data={[devboxSchema, breadcrumbSchema]} />
 
-      <div className="h-full min-h-screen bg-white">
-        <Header lang={params.lang} />
-        <main className="custom-container px-8 pt-14 md:px-[15%]">
-          <Hero
-            title={t.title}
-            mainTitleEmphasis={3}
-            getStartedLink={`${appDomain}/?openapp=system-devbox`}
-            getStartedText={
-              params.lang === 'zh-cn'
-                ? '免费开始（无需信用卡）'
-                : 'Start Free – No Credit Card'
-            }
-            lang={params.lang}
-            videoCta={true}
-            secondaryCta={{
-              title: t.watchDemo,
-              href: '#video-section',
-            }}
-          >
-            <USPChips lang={params.lang} />
-            <div id="video-section" className="mt-8">
-              <Video
-                url="https://www.youtube.com/watch?v=TrEsUMwWtDg"
-                placeholderImage={placeholderImage}
-                title="Sealos DevBox"
-                location="hero"
-              />
+      <div className="min-h-screen overflow-x-clip text-white">
+        <div className="sticky top-0 z-50 container pt-8">
+          <Header lang={params.lang} />
+        </div>
+
+        <main className="-mt-24 overflow-x-clip bg-black">
+          <section className="relative overflow-hidden pt-36 pb-16 sm:pt-44 sm:pb-24 lg:pt-48 lg:pb-28">
+            <HeroBackground />
+            <GodRays
+              sources={[
+                {
+                  x: -0.05,
+                  y: -0.05,
+                  angle: 60,
+                  spread: 20,
+                  count: 12,
+                  color: '220, 220, 220',
+                  opacityMin: 0.24,
+                  opacityMax: 0.25,
+                  minWidth: 120,
+                  maxWidth: 180,
+                },
+                {
+                  x: -0.05,
+                  y: -0.05,
+                  angle: 60,
+                  spread: 8,
+                  count: 6,
+                  color: '255, 255, 255',
+                  opacityMin: 0.84,
+                  opacityMax: 0.85,
+                  minWidth: 12,
+                  maxWidth: 24,
+                },
+                {
+                  x: 0.25,
+                  y: -0.06,
+                  angle: 50,
+                  spread: 20,
+                  count: 6,
+                  color: '180, 180, 180',
+                  opacityMin: 0.14,
+                  opacityMax: 0.15,
+                  minWidth: 60,
+                  maxWidth: 120,
+                },
+              ]}
+              speed={0}
+              maxWidth={48}
+              minLength={1200}
+              maxLength={2000}
+              blur={8}
+            />
+
+            <div className="relative z-10 container">
+              <div className="mx-auto max-w-5xl text-center">
+                <USPChips lang={params.lang} />
+                <h1 className="mt-10 text-4xl leading-tight font-medium tracking-normal text-white sm:text-6xl lg:text-7xl">
+                  {t.title.main}
+                </h1>
+                <p className="mx-auto mt-6 max-w-3xl bg-linear-to-r from-white to-blue-600 bg-clip-text text-2xl leading-tight font-medium text-transparent sm:text-4xl lg:text-5xl">
+                  {t.title.sub}
+                </p>
+                <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-zinc-400 sm:text-lg">
+                  {t.description}
+                </p>
+                <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:flex-row">
+                  <Button
+                    asChild
+                    variant="landing-primary"
+                    size="lg"
+                    className="h-12 w-full px-7 text-base sm:w-auto"
+                  >
+                    <a href={`${appDomain}/?openapp=system-devbox`}>
+                      {params.lang === 'zh-cn'
+                        ? '免费开始（无需信用卡）'
+                        : 'Start Free – No Credit Card'}
+                    </a>
+                  </Button>
+                  <a
+                    href="#video-section"
+                    className="inline-flex h-12 w-full items-center justify-center rounded-full border border-white/15 bg-white/5 px-7 text-base font-medium text-white backdrop-blur transition-colors hover:bg-white/10 sm:w-auto"
+                  >
+                    {t.watchDemo}
+                  </a>
+                </div>
+              </div>
+
+              <div
+                id="video-section"
+                className="mx-auto mt-12 w-full max-w-5xl scroll-mt-28 rounded-3xl border border-white/10 bg-white/[0.03] p-2 shadow-[0_24px_80px_rgba(20,109,255,0.18)] backdrop-blur sm:p-3"
+              >
+                <div className="overflow-hidden rounded-2xl border border-white/10">
+                  <Video
+                    url="https://www.youtube.com/watch?v=TrEsUMwWtDg"
+                    placeholderImage={placeholderImage}
+                    title="Sealos DevBox"
+                    location="hero"
+                  />
+                </div>
+              </div>
+
+              <PositioningStrip lang={params.lang} />
             </div>
-          </Hero>
+          </section>
 
-          {/* Positioning Strip */}
-          <PositioningStrip lang={params.lang} />
+          <div className="container space-y-16 pb-20 sm:space-y-24 lg:space-y-28">
+            <SocialProof lang={params.lang} />
+            <Problems lang={params.lang} />
+            <Solutions lang={params.lang} />
+            <Workflow lang={params.lang} />
+            <MetricsVisualization lang={params.lang} />
 
-          {/* Social Proof Section */}
-          <SocialProof lang={params.lang} />
-
-          {/* Problem-Solution Structure */}
-          <Problems lang={params.lang} />
-          <Solutions lang={params.lang} />
-
-          {/* Development Workflow */}
-          <Workflow lang={params.lang} />
-
-          {/* Metrics Visualization */}
-          <MetricsVisualization lang={params.lang} />
-
-          {/* Template Deployment Section */}
-          <div id="one-click-deployment" className="scroll-mt-20" />
-          <TechGrid />
-
-          <FooterCta lang={params.lang} />
+            <div id="one-click-deployment" className="scroll-mt-28" />
+            <TechGrid />
+            <FooterCta lang={params.lang} />
+          </div>
         </main>
-        <div className="mt-[140px] h-[1px] bg-[#DDE7F7]"></div>
-        <Footer lang={params.lang} />
+
+        <div className="relative mt-[80px] mb-[400px] h-[800px]">
+          <div className="w-full">
+            <Image
+              src={BottomLightImage}
+              alt=""
+              className="h-auto w-full object-cover select-none"
+              priority
+              fill
+            />
+          </div>
+
+          <Footer lang={params.lang} />
+        </div>
       </div>
     </>
   );

--- a/app/[lang]/utils/is-forced-dark-mode.ts
+++ b/app/[lang]/utils/is-forced-dark-mode.ts
@@ -38,6 +38,10 @@ export function isForcedDarkMode(pathname: string): boolean {
       match: 'prefix',
     },
     {
+      path: '/products/devbox',
+      match: 'prefix',
+    },
+    {
       path: '/abuse',
       match: 'full',
     },


### PR DESCRIPTION
## Summary

Redesigns the `/products/devbox` product page so it matches the current homepage visual language while preserving the existing DevBox copy.

The page now uses the homepage dark shell, frosted header, HeroBackground, GodRays treatment, bottom light asset, and shared homepage footer. DevBox-owned sections were restyled for the same dark editorial system, with responsive layouts for mobile and desktop.

## Changes

- Replace the legacy light DevBox shell with the homepage `Header`, `Footer`, `HeroBackground`, `GodRays`, and bottom light composition.
- Restyle DevBox section components as dark glass panels, timeline blocks, stats, comparison tables, tabs, and CTA surfaces.
- Preserve existing English and Chinese DevBox page copy.
- Add `/products/devbox` to forced dark-mode route matching so shared chrome renders consistently.
- Align the DevBox footer wrapper with the homepage footer spacing so the fixed bottom Sealos wordmark layer is visible.

## Key Files

- `app/[lang]/products/devbox/page.tsx`
- `app/[lang]/products/devbox/components/footerCta.tsx`
- `app/[lang]/products/devbox/components/metrics-visualization.tsx`
- `app/[lang]/products/devbox/components/positioning-strip.tsx`
- `app/[lang]/products/devbox/components/problems.tsx`
- `app/[lang]/products/devbox/components/social-proof.tsx`
- `app/[lang]/products/devbox/components/solutions-v2.tsx`
- `app/[lang]/products/devbox/components/techgrid.tsx`
- `app/[lang]/products/devbox/components/usp-chips.tsx`
- `app/[lang]/products/devbox/components/workflow-v2.tsx`
- `app/[lang]/utils/is-forced-dark-mode.ts`

## Verification

- [x] `npm run lint`
- [x] `git diff --check upstream/main...HEAD`
- [x] `rm -rf .next && npm run build`
- [x] Local visual QA for `http://localhost:3000/products/devbox/` on desktop and mobile
- [x] Footer follow-up QA confirmed the bottom Sealos wordmark layer is visible

Known build warnings observed during verification:

- Next.js static export reports configured rewrites are not applied to export output.
- Browserslist reports `caniuse-lite` data is outdated.
- Native `sharp`/`canvas` libraries report duplicate `GNotificationCenterDelegate` classes during static generation.
- The App Store template API and one markdown fetch logged transient network failures during static generation, and the existing fallback path completed the build successfully.

## TDD Audit

| Test commit | Impl commit | gate_status |
|---|---|---|
| — | `ef63dc9` feat(devbox): redesign product page to match homepage | missing |

Aggregate: 0 skill, 0 fallback, 0 exempt, 1 missing.

gate_status: skill=0, fallback=0, exempt=0, missing=1
