### PR TITLE
docs(blog): add Playwright verification guidance to Cloud Run article

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -6,9 +6,9 @@ current_phase: 28
 current_phase_name: Catalog Publication and Cleanup
 status: complete
 stopped_at: Milestone v1.3 complete
-last_updated: "2026-07-16T22:23:44.169Z"
-last_activity: 2026-07-17
-last_activity_desc: Milestone v1.3 complete
+last_updated: "2026-07-20T03:50:34Z"
+last_activity: 2026-07-20
+last_activity_desc: Completed quick task 260720-g4e: Add Playwright verification guidance to the Cloud Run article
 progress:
   total_phases: 8
   completed_phases: 8
@@ -68,6 +68,8 @@ Milestone v1.3 is complete.
 | 260617-kt3 | fix GHCR Docker image build failure | 2026-06-17 | fe42f4d | [260617-kt3-fix-ghcr-docker-image-build-failure](./quick/260617-kt3-fix-ghcr-docker-image-build-failure/) |
 | 260708-q6y | Redesign /products/databases to match the current homepage style, keep existing copy except Kafka removal, and validate mobile usability | 2026-07-08 | PR #304 | [260708-q6y-redesign-products-databases-to-match-the](./quick/260708-q6y-redesign-products-databases-to-match-the/) |
 | 260709-n35 | Fix /products/databases footer bottom Sealos word to match homepage | 2026-07-09 | PR #304 | [260709-n35-fix-products-databases-footer-bottom-sea](./quick/260709-n35-fix-products-databases-footer-bottom-sea/) |
+| 260720-g4e | Add Playwright verification guidance to the Cloud Run article | 2026-07-20 | e9314f2 | [260720-g4e-update-the-sealos-io-blog-article-for-th](./quick/260720-g4e-update-the-sealos-io-blog-article-for-th/) |
+
 
 ## Performance Metrics
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -8,7 +8,7 @@ status: complete
 stopped_at: Milestone v1.3 complete
 last_updated: "2026-07-20T03:50:34Z"
 last_activity: 2026-07-20
-last_activity_desc: Completed quick task 260720-g4e: Add Playwright verification guidance to the Cloud Run article
+last_activity_desc: Opened upstream PR #309 for quick task 260720-g4e: Add Playwright verification guidance to the Cloud Run article
 progress:
   total_phases: 8
   completed_phases: 8
@@ -48,7 +48,7 @@ All Phase 28 requirements are complete.
 Phase: 28 (Catalog Publication and Cleanup) — COMPLETE
 Plan: 3 of 3
 Status: Milestone v1.3 complete
-Last activity: 2026-07-17 — Phase 28 verification passed
+Last activity: 2026-07-20 — Opened upstream PR #309 for quick task 260720-g4e
 
 ## Next Action
 

--- a/.planning/quick/260720-g4e-update-the-sealos-io-blog-article-for-th/260720-g4e-PLAN.md
+++ b/.planning/quick/260720-g4e-update-the-sealos-io-blog-article-for-th/260720-g4e-PLAN.md
@@ -1,0 +1,45 @@
+---
+quick_id: 260720-g4e
+status: planned
+created: 2026-07-20
+---
+
+# Quick Task 260720-g4e: Add Playwright verification guidance to the Cloud Run article
+
+## Goal
+
+Add the requested browser-verification guidance to the Sealos.io Cloud Run blog article while preserving the existing English MDX structure and surrounding content.
+
+## Source
+
+- URL: `https://sealos.io/blog/what-is-cloud-run/`
+- Likely source: `content/blog/(what-is)/what-is-cloud-run/index.en.md`
+- Anchor point: the paragraph ending with `This architecture allows developers to test applications locally with identical behavior to production deployments, eliminating many environment-specific issues that plague traditional development workflows.`
+
+## Scope Audit
+
+- User request: Covered by the insertion and link requirements in Task 1.
+- Project language and content conventions: Covered by the English-only MDX edit and focused validation in Tasks 1-2.
+- Local source evidence: Covered by the named MDX file and exact anchor sentence above.
+- Research and additional decisions: None required for this source-only content update.
+
+## Tasks
+
+1. Insert the Playwright automation paragraph immediately after the anchor sentence.
+   - Files: `content/blog/(what-is)/what-is-cloud-run/index.en.md`
+   - Action: Add this exact standalone paragraph directly after the paragraph containing the anchor sentence: `Teams deploying containerized web applications can use [playwright automation](https://testgrid.io/blog/playwright-testing/) to verify browser functionality across local, staging, and Cloud Run environments before routing production traffic to a new container revision.` Keep the anchor text exactly `playwright automation`, apply the destination URL only to that anchor text, and preserve the following code block and remote-testing content.
+   - Verify: Run a Node text assertion that counts the anchor sentence, the exact adjacent anchor-sentence-plus-paragraph sequence, `[playwright automation](https://testgrid.io/blog/playwright-testing/)`, and `https://testgrid.io/blog/playwright-testing/`; each count must equal one.
+   - Done: The article contains the requested English paragraph at the required location, with exactly one link whose anchor is `playwright automation` and whose target is `https://testgrid.io/blog/playwright-testing/`.
+
+2. Run focused source validation.
+   - Files: `content/blog/(what-is)/what-is-cloud-run/index.en.md`
+   - Action: Inspect the source diff for a single inserted paragraph and validate MDX formatting for the changed file.
+   - Verify: Run `git diff --check -- 'content/blog/(what-is)/what-is-cloud-run/index.en.md'` and `npm exec -- prettier --check -- 'content/blog/(what-is)/what-is-cloud-run/index.en.md'`, together with the exact adjacency and link-count assertion from Task 1.
+   - Done: The focused checks pass and the diff contains only the requested paragraph insertion.
+
+## Success Criteria
+
+- The likely MDX source file is the only content file changed.
+- The Playwright guidance follows the specified Cloud Run testing sentence immediately.
+- Only `playwright automation` is linked to the requested TestGrid URL.
+- Focused whitespace, formatting, adjacency, and link-count checks pass.

--- a/.planning/quick/260720-g4e-update-the-sealos-io-blog-article-for-th/260720-g4e-SUMMARY.md
+++ b/.planning/quick/260720-g4e-update-the-sealos-io-blog-article-for-th/260720-g4e-SUMMARY.md
@@ -1,0 +1,55 @@
+---
+status: complete
+quick_id: 260720-g4e
+completed: 2026-07-20
+commit: e9314f2
+---
+
+# Quick Task 260720-g4e Summary
+
+**Added exact Playwright browser-verification guidance to the Cloud Run article after the local testing paragraph.**
+
+## Completed
+
+- Inserted the requested English paragraph immediately after the specified Cloud Run testing sentence.
+- Preserved the following bash code block and remote-testing content.
+- Kept `playwright automation` as the exact anchor text and used the exact TestGrid URL.
+
+## Verification
+
+- Node adjacency and link-count assertions: passed; each required count is `1`.
+- `git diff --check -- 'content/blog/(what-is)/what-is-cloud-run/index.en.md'`: passed.
+- `npm exec -- prettier --check -- 'content/blog/(what-is)/what-is-cloud-run/index.en.md'`: exited `1` because the worktree lacks installed dependencies and the configured `prettier-plugin-tailwindcss` package could not be imported.
+- `npm exec -- prettier --no-config --check -- 'content/blog/(what-is)/what-is-cloud-run/index.en.md'`: reported existing full-file formatting differences; the source remained surgical to preserve surrounding content.
+- Final commit diff: one source file, two inserted lines, zero deletions.
+
+## Task Commit
+
+- `e9314f2` - `docs(260720-g4e): add Playwright verification guidance to Cloud Run article`
+
+## Files Modified
+
+- `content/blog/(what-is)/what-is-cloud-run/index.en.md` - Added the requested standalone paragraph.
+
+## Deviations from Plan
+
+The exact Prettier command reached the repository configuration and exposed a missing local dependency installation. The declared packages remain in `package.json` and `package-lock.json`; dependency installation was outside the source-only scope. Content assertions and whitespace validation passed, and the commit contains only the requested source change.
+
+## Known Stubs
+
+None.
+
+## Threat Surface Scan
+
+No new security-relevant surface was introduced; this task changes one static Markdown paragraph.
+
+## Planning Artifacts
+
+The SUMMARY and STATE updates remain under `.planning/` and are intentionally uncommitted. The source content commit is atomic.
+
+## Self-Check: PASSED
+
+- SUMMARY and STATE files exist.
+- Commit `e9314f2` exists in git history.
+- The commit contains only `content/blog/(what-is)/what-is-cloud-run/index.en.md`.
+- Anchor, adjacency, and link-count assertions each return `1`.

--- a/content/blog/(what-is)/what-is-cloud-run/index.en.md
+++ b/content/blog/(what-is)/what-is-cloud-run/index.en.md
@@ -211,6 +211,8 @@ The **future-proof architecture** that Knative provides means that applications 
 
 Cloud Run containers function as **complete, independent web servers**, enabling sophisticated testing strategies that weren't possible with traditional serverless platforms. This architecture allows developers to test applications locally with identical behavior to production deployments, eliminating many environment-specific issues that plague traditional development workflows.
 
+Teams deploying containerized web applications can use [playwright automation](https://testgrid.io/blog/playwright-testing/) to verify browser functionality across local, staging, and Cloud Run environments before routing production traffic to a new container revision.
+
 ```bash
 # Test locally with identical environment to production
 docker run -p 8080:8080 my-app


### PR DESCRIPTION
## Summary

Add browser verification guidance to the Cloud Run article for teams deploying containerized web applications.

## Changes

- Add the requested paragraph immediately after the local and production behavior explanation.
- Link the exact anchor text `playwright automation` to the TestGrid Playwright testing article.
- Preserve the surrounding code block and remote testing guidance.
- Rebase the branch onto the latest `upstream/main`.

## Verification

- Node adjacency and link-count assertions passed: anchor, adjacent paragraph, and target link each occur once.
- `git diff --check upstream/main...HEAD` passed.
- The configured Prettier check remains environment-limited because `prettier-plugin-tailwindcss` is not installed in the worktree; the source diff remains limited to the requested paragraph.

## Planning

- GSD quick task: `260720-g4e`
- Source commit: `e9314f2`
- Planning record commit: `2d30ef3`