### PR TITLE
fix(app-store): redirect legacy LobeHub URLs

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -7,8 +7,8 @@ current_phase_name: Catalog Publication and Cleanup
 status: complete
 stopped_at: Milestone v1.3 complete
 last_updated: "2026-07-20T03:50:34Z"
-last_activity: 2026-07-20
-last_activity_desc: Opened upstream PR #309 for quick task 260720-g4e: Add Playwright verification guidance to the Cloud Run article
+last_activity: 2026-07-21
+last_activity_desc: "Completed quick task 260721-n8f: Add permanent LobeHub legacy app-store redirects across Vercel and Cloudflare Pages"
 progress:
   total_phases: 8
   completed_phases: 8
@@ -48,7 +48,8 @@ All Phase 28 requirements are complete.
 Phase: 28 (Catalog Publication and Cleanup) — COMPLETE
 Plan: 3 of 3
 Status: Milestone v1.3 complete
-Last activity: 2026-07-20 — Opened upstream PR #309 for quick task 260720-g4e
+Last activity: 2026-07-21 — Completed quick task 260721-n8f: Add permanent
+LobeHub legacy app-store redirects across Vercel and Cloudflare Pages
 
 ## Next Action
 
@@ -69,7 +70,7 @@ Milestone v1.3 is complete.
 | 260708-q6y | Redesign /products/databases to match the current homepage style, keep existing copy except Kafka removal, and validate mobile usability | 2026-07-08 | PR #304 | [260708-q6y-redesign-products-databases-to-match-the](./quick/260708-q6y-redesign-products-databases-to-match-the/) |
 | 260709-n35 | Fix /products/databases footer bottom Sealos word to match homepage | 2026-07-09 | PR #304 | [260709-n35-fix-products-databases-footer-bottom-sea](./quick/260709-n35-fix-products-databases-footer-bottom-sea/) |
 | 260720-g4e | Add Playwright verification guidance to the Cloud Run article | 2026-07-20 | e9314f2 | [260720-g4e-update-the-sealos-io-blog-article-for-th](./quick/260720-g4e-update-the-sealos-io-blog-article-for-th/) |
-
+| 260721-n8f | Add permanent LobeHub legacy app-store redirects across Vercel and Cloudflare Pages | 2026-07-21 | ef5aad0 | [260721-n8f-add-permanent-lobehub-legacy-app-store-r](./quick/260721-n8f-add-permanent-lobehub-legacy-app-store-r/) |
 
 ## Performance Metrics
 

--- a/.planning/quick/260721-n8f-add-permanent-lobehub-legacy-app-store-r/260721-n8f-PLAN.md
+++ b/.planning/quick/260721-n8f-add-permanent-lobehub-legacy-app-store-r/260721-n8f-PLAN.md
@@ -1,0 +1,30 @@
+---
+quick_id: 260721-n8f
+status: planned
+created: 2026-07-21
+---
+
+# Quick Task 260721-n8f: Add permanent LobeHub legacy app-store redirects across Vercel and Cloudflare Pages
+
+## Goal
+
+Route both legacy Lobe Chat app-store slugs to the canonical LobeHub detail
+page with one permanent redirect across the supported static hosting targets.
+
+## Tasks
+
+1. Add canonical LobeHub redirects to both hosting configurations.
+   - Files: `vercel.json`, `public/_redirects`
+   - Action: Add exact redirect rules for `lobe-chat` and `lobe-chat-db`,
+     covering requests with and without a trailing slash. Send every source to
+     `/products/app-store/lobehub/` with permanent HTTP 308 semantics.
+   - Verify: Parse `vercel.json` and inspect the four Vercel and Cloudflare
+     rule pairs for matching sources, destinations, and statuses.
+
+2. Validate redirect parsing and deployment parity.
+   - Files: `scripts/check-static-output.js`,
+     `scripts/check-static-output.test.mjs`
+   - Action: Use the existing source checks as the regression gate for the
+     declarative redirect changes.
+   - Verify: Run `node --test scripts/check-static-output.test.mjs`,
+     `npm run static-output:check`, and `git diff --check`.

--- a/.planning/quick/260721-n8f-add-permanent-lobehub-legacy-app-store-r/260721-n8f-SUMMARY.md
+++ b/.planning/quick/260721-n8f-add-permanent-lobehub-legacy-app-store-r/260721-n8f-SUMMARY.md
@@ -1,0 +1,28 @@
+---
+status: complete
+quick_id: 260721-n8f
+completed: 2026-07-21
+---
+
+# Quick Task 260721-n8f Summary
+
+## Completed
+
+- Added permanent Vercel redirects for the `lobe-chat` and `lobe-chat-db`
+  app-store paths, covering requests with and without a trailing slash.
+- Added matching Cloudflare Pages redirects with HTTP 308 status codes.
+- Pointed every legacy URL directly to the canonical
+  `/products/app-store/lobehub/` path.
+
+## Verification
+
+- Exact-rule assertion verified all four Vercel and Cloudflare redirect pairs.
+- `node --test scripts/check-static-output.test.mjs` passed 7 tests.
+- `npm run static-output:check` passed all source configuration, redirect
+  parity, and route policy checks. Static artifact inspection remains gated
+  until an `out` directory is available.
+- `git diff --check` passed.
+
+## Commit
+
+`ef5aad0` (`fix(app-store): redirect legacy LobeHub URLs`)

--- a/public/_redirects
+++ b/public/_redirects
@@ -23,6 +23,10 @@ https://sealos.run/en/* https://sealos.io/:splat 302
 /robots.txt /api/robots 200
 
 # Vercel redirect parity
+/products/app-store/lobe-chat /products/app-store/lobehub/ 308
+/products/app-store/lobe-chat/ /products/app-store/lobehub/ 308
+/products/app-store/lobe-chat-db /products/app-store/lobehub/ 308
+/products/app-store/lobe-chat-db/ /products/app-store/lobehub/ 308
 /docs/guides/fundamentals https://sealos.io/docs/guides/devbox/ 308
 /docs/guides/fundamentals/create-a-project https://sealos.io/docs/guides/devbox/create-a-project/ 308
 /docs/guides/fundamentals/develop https://sealos.io/docs/guides/devbox/develop/ 308

--- a/vercel.json
+++ b/vercel.json
@@ -21,6 +21,26 @@
   ],
   "redirects": [
     {
+      "source": "/products/app-store/lobe-chat",
+      "destination": "/products/app-store/lobehub/",
+      "permanent": true
+    },
+    {
+      "source": "/products/app-store/lobe-chat/",
+      "destination": "/products/app-store/lobehub/",
+      "permanent": true
+    },
+    {
+      "source": "/products/app-store/lobe-chat-db",
+      "destination": "/products/app-store/lobehub/",
+      "permanent": true
+    },
+    {
+      "source": "/products/app-store/lobe-chat-db/",
+      "destination": "/products/app-store/lobehub/",
+      "permanent": true
+    },
+    {
       "source": "/docs/guides/fundamentals",
       "destination": "https://sealos.io/docs/guides/devbox/",
       "permanent": true


### PR DESCRIPTION
## Summary

- add permanent redirects from the legacy `lobe-chat` and `lobe-chat-db` App Store URLs to `/products/app-store/lobehub/`
- cover both trailing-slash and non-trailing-slash request forms
- keep Vercel and Cloudflare Pages redirect behavior aligned with HTTP 308 semantics

## Verification

- `node --test scripts/check-static-output.test.mjs` (7 tests passed)
- `npm run static-output:check` (source configuration, redirect parity, and route policy passed)
- exact-rule assertion verified all four redirect pairs after rebasing onto `upstream/main`
- `git diff --check upstream/main...HEAD`
