### PR TITLE
feat(analytics): add stable Rybbit CTA identifiers

### DIFF
--- a/app/[lang]/(home)/(new-home)/sections/cta/cta-section.tsx
+++ b/app/[lang]/(home)/(new-home)/sections/cta/cta-section.tsx
@@ -6,6 +6,7 @@ import { StarBorder } from '@/components/ui/star-border';
 import { useGTM } from '@/hooks/use-gtm';
 import { useAuthRedirect } from '@/hooks/use-auth-redirect';
 import { getOpenBrainParam } from '@/lib/utils/brain';
+import { getRybbitCtaProps } from '@/lib/analytics/rybbit-cta';
 import { GradientText } from '@/new-components/GradientText';
 
 import styles from './cta-section.module.css';
@@ -35,6 +36,11 @@ export function CTASection() {
           <StarBorder
             color="white"
             contentClassName="h-10 gap-2 border border-white bg-gradient-to-b from-white via-zinc-100 to-zinc-300 px-4 text-sm font-medium text-zinc-900 shadow-lg"
+            {...getRybbitCtaProps({
+              id: 'home_bottom_deploy_free',
+              location: 'bottom_cta',
+              destination: 'signup_modal',
+            })}
             onClick={() => {
               trackButton('Deploy for free', 'home_cta', 'auth-form', '');
               handleAuthRedirect({ openapp: getOpenBrainParam() });

--- a/app/[lang]/(home)/(new-home)/sections/hero/hero-section.tsx
+++ b/app/[lang]/(home)/(new-home)/sections/hero/hero-section.tsx
@@ -21,6 +21,7 @@ import { StarBorder } from '@/components/ui/star-border';
 import { useGTM } from '@/hooks/use-gtm';
 import { useAuthRedirect } from '@/hooks/use-auth-redirect';
 import { getOpenBrainParam } from '@/lib/utils/brain';
+import { getRybbitCtaProps } from '@/lib/analytics/rybbit-cta';
 import { GradientText } from '@/new-components/GradientText';
 import { SideRays } from '@/new-components/SideRays';
 
@@ -146,6 +147,11 @@ function HeroGetStartedButton() {
       <StarBorder
         color="var(--color-blue-500)"
         contentClassName="h-10 gap-2 border border-blue-500/80 bg-gradient-to-b from-white via-zinc-100 to-zinc-300 px-4 text-sm font-medium text-zinc-900 shadow-lg"
+        {...getRybbitCtaProps({
+          id: 'home_hero_get_started',
+          location: 'hero',
+          destination: 'signup_modal',
+        })}
         onClick={() => {
           trackButton('Get Started', 'hero', 'auth-form', '');
           handleAuthRedirect({ openapp: getOpenBrainParam() });

--- a/app/[lang]/(home)/pricing/components/FreeTrialCard.tsx
+++ b/app/[lang]/(home)/pricing/components/FreeTrialCard.tsx
@@ -7,6 +7,7 @@ import { GradientText } from '@/new-components/GradientText';
 import { FeatureItem } from './FeatureItem';
 import { cn } from '@/lib/utils';
 import { useGTM } from '@/hooks/use-gtm';
+import { getRybbitCtaProps } from '@/lib/analytics/rybbit-cta';
 
 interface FreeTrialCardProps {
   className?: string;
@@ -63,6 +64,11 @@ export function FreeTrialCard({ className }: FreeTrialCardProps) {
         <Button
           variant="landing-primary"
           className="h-10 px-8"
+          {...getRybbitCtaProps({
+            id: 'pricing_free_trial_start_deploying',
+            location: 'pricing_free_trial_card',
+            destination: 'costcenter_topup',
+          })}
           onClick={handleStartDeploying}
         >
           <span>Start Deploying</span>

--- a/app/[lang]/(home)/pricing/components/MorePlans.tsx
+++ b/app/[lang]/(home)/pricing/components/MorePlans.tsx
@@ -13,6 +13,7 @@ import { cn } from '@/lib/utils';
 import { useAuthRedirect } from '@/hooks/use-auth-redirect';
 import { useGTM } from '@/hooks/use-gtm';
 import { morePlans, type PricingPlan } from '../config/plans';
+import { getRybbitCtaProps, toRybbitCtaId } from '@/lib/analytics/rybbit-cta';
 
 interface MorePlansProps {
   className?: string;
@@ -159,6 +160,12 @@ export function MorePlans({ className }: MorePlansProps) {
         <Button
           variant="secondary"
           className="h-11 shrink-0 rounded-full px-8"
+          {...getRybbitCtaProps({
+            id: `pricing_${toRybbitCtaId(selectedPlan.name)}_get_started`,
+            location: 'pricing_more_plans',
+            destination:
+              selectedPlan.action.type === 'auth' ? 'signup_modal' : 'checkout',
+          })}
           onClick={handleGetStarted}
         >
           Get Started

--- a/app/[lang]/(home)/pricing/components/PricingCard.tsx
+++ b/app/[lang]/(home)/pricing/components/PricingCard.tsx
@@ -6,6 +6,7 @@ import { FeatureItem } from './FeatureItem';
 import { useAuthRedirect } from '@/hooks/use-auth-redirect';
 import { useGTM } from '@/hooks/use-gtm';
 import type { PricingPlan } from '../config/plans';
+import { getRybbitCtaProps, toRybbitCtaId } from '@/lib/analytics/rybbit-cta';
 
 interface PricingCardProps {
   plan: PricingPlan;
@@ -71,6 +72,11 @@ export function PricingCard({ plan, className }: PricingCardProps) {
       <Button
         variant={isPopular ? 'landing-primary' : buttonVariant}
         className="h-11 rounded-full"
+        {...getRybbitCtaProps({
+          id: `pricing_${toRybbitCtaId(name)}_get_started`,
+          location: 'pricing_plan_card',
+          destination: action.type === 'auth' ? 'signup_modal' : 'checkout',
+        })}
         onClick={handleButtonClick}
       >
         {buttonText}

--- a/lib/analytics/rybbit-cta.ts
+++ b/lib/analytics/rybbit-cta.ts
@@ -1,0 +1,35 @@
+export type RybbitCtaTracking = {
+  id: string;
+  location: string;
+  destination: string;
+};
+
+export function toRybbitCtaId(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+type RybbitCtaDomProps = {
+  'data-rybbit-prop-cta-id': string;
+  'data-rybbit-prop-cta-location': string;
+  'data-rybbit-prop-cta-destination': string;
+};
+
+/**
+ * Adds stable business identifiers to the real clickable element so Rybbit's
+ * native button autocapture can be queried independently of visible copy.
+ */
+export function getRybbitCtaProps({
+  id,
+  location,
+  destination,
+}: RybbitCtaTracking): RybbitCtaDomProps {
+  return {
+    'data-rybbit-prop-cta-id': id,
+    'data-rybbit-prop-cta-location': location,
+    'data-rybbit-prop-cta-destination': destination,
+  };
+}

--- a/new-components/Footer/StartBuildingButton.tsx
+++ b/new-components/Footer/StartBuildingButton.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { ArrowRight } from 'lucide-react';
 import { useAuthRedirect } from '@/hooks/use-auth-redirect';
 import { getOpenBrainParam } from '@/lib/utils/brain';
+import { getRybbitCtaProps } from '@/lib/analytics/rybbit-cta';
 
 export function StartBuildingButton({ className }: { className?: string }) {
   const { trackButton } = useGTM();
@@ -13,6 +14,11 @@ export function StartBuildingButton({ className }: { className?: string }) {
   return (
     <Button
       variant="landing-primary"
+      {...getRybbitCtaProps({
+        id: 'home_footer_start_building',
+        location: 'footer_cta',
+        destination: 'signup_modal',
+      })}
       onClick={() => {
         trackButton('Get Started', 'footer', 'auth-form', '');
         handleAuthRedirect({ openapp: getOpenBrainParam() });

--- a/new-components/Header.tsx
+++ b/new-components/Header.tsx
@@ -36,6 +36,7 @@ import { siteConfig } from '@/config/site';
 import { useAuthRedirect } from '@/hooks/use-auth-redirect';
 import { getOpenBrainParam } from '@/lib/utils/brain';
 import { i18n, languagesType } from '@/lib/i18n';
+import { getRybbitCtaProps } from '@/lib/analytics/rybbit-cta';
 
 type NavigationChild = {
   text: string;
@@ -368,6 +369,11 @@ export function Header({ lang }: HeaderProps) {
               variant="landing-primary"
               className="hidden h-10 rounded-full px-4 py-2 text-sm font-medium shadow-lg lg:flex"
               aria-label="Start using Sealos for free."
+              {...getRybbitCtaProps({
+                id: 'home_header_get_started',
+                location: 'header',
+                destination: 'signup_modal',
+              })}
               onClick={() => {
                 trackButton('Get Started', 'header', 'auth-form', '');
                 handleAuthRedirect({ openapp: getOpenBrainParam() });
@@ -546,6 +552,11 @@ export function Header({ lang }: HeaderProps) {
                       variant="landing-primary"
                       className="h-12 w-full border border-white text-base"
                       aria-label="Start using Sealos for free."
+                      {...getRybbitCtaProps({
+                        id: 'home_header_mobile_get_started',
+                        location: 'header_mobile_menu',
+                        destination: 'signup_modal',
+                      })}
                       onClick={() => {
                         trackButton(
                           'Get Started',

--- a/tests/rybbit-cta.test.ts
+++ b/tests/rybbit-cta.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  getRybbitCtaProps,
+  toRybbitCtaId,
+} from '../lib/analytics/rybbit-cta.ts';
+
+const root = process.cwd();
+
+const readSource = (filePath: string) =>
+  readFileSync(path.join(root, filePath), 'utf8');
+
+test('Rybbit CTA helper exposes the stable DOM property contract', () => {
+  assert.deepEqual(
+    getRybbitCtaProps({
+      id: 'home_header_get_started',
+      location: 'header',
+      destination: 'signup_modal',
+    }),
+    {
+      'data-rybbit-prop-cta-id': 'home_header_get_started',
+      'data-rybbit-prop-cta-location': 'header',
+      'data-rybbit-prop-cta-destination': 'signup_modal',
+    },
+  );
+});
+
+const homepageCtas = [
+  {
+    file: 'new-components/Header.tsx',
+    id: 'home_header_get_started',
+  },
+  {
+    file: 'new-components/Header.tsx',
+    id: 'home_header_mobile_get_started',
+  },
+  {
+    file: 'app/[lang]/(home)/(new-home)/sections/hero/hero-section.tsx',
+    id: 'home_hero_get_started',
+  },
+  {
+    file: 'app/[lang]/(home)/(new-home)/sections/cta/cta-section.tsx',
+    id: 'home_bottom_deploy_free',
+  },
+  {
+    file: 'new-components/Footer/StartBuildingButton.tsx',
+    id: 'home_footer_start_building',
+  },
+];
+
+const pricingCtas = [
+  {
+    file: 'app/[lang]/(home)/pricing/components/PricingCard.tsx',
+    idSource: 'id: `pricing_${toRybbitCtaId(name)}_get_started`',
+  },
+  {
+    file: 'app/[lang]/(home)/pricing/components/FreeTrialCard.tsx',
+    idSource: "id: 'pricing_free_trial_start_deploying'",
+  },
+  {
+    file: 'app/[lang]/(home)/pricing/components/MorePlans.tsx',
+    idSource: 'id: `pricing_${toRybbitCtaId(selectedPlan.name)}_get_started`',
+  },
+];
+
+test('homepage conversion CTAs use unique stable Rybbit CTA IDs', () => {
+  const seenIds = new Set<string>();
+
+  for (const cta of homepageCtas) {
+    const source = readSource(cta.file);
+
+    assert.match(
+      source,
+      new RegExp(`id: ['"]${cta.id}['"]`),
+      `${cta.file} must declare ${cta.id}`,
+    );
+    assert.equal(seenIds.has(cta.id), false, `${cta.id} must be unique`);
+    seenIds.add(cta.id);
+  }
+});
+
+test('Pricing CTA IDs normalize dynamic plan names', () => {
+  assert.equal(toRybbitCtaId('Pro Plan'), 'pro_plan');
+  assert.equal(toRybbitCtaId('GPU / H100'), 'gpu_h100');
+  assert.equal(toRybbitCtaId('  Free Trial  '), 'free_trial');
+
+  for (const cta of pricingCtas) {
+    assert.ok(
+      readSource(cta.file).includes(cta.idSource),
+      `${cta.file} must declare ${cta.idSource}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- add a reusable helper for stable Rybbit CTA DOM properties
- instrument homepage header, hero, bottom, and footer conversion CTAs
- instrument pricing plan and free-trial CTAs, including normalized dynamic plan IDs
- keep the existing GTM `button_click` dataLayer flow while enriching Rybbit native button autocapture

## Event contract

Rybbit continues to record these interactions as native button events:

```text
type = button_click
event_name = ""
properties["cta-id"] = <stable CTA ID>
```

Each tracked element now exposes:

```text
data-rybbit-prop-cta-id
data-rybbit-prop-cta-location
data-rybbit-prop-cta-destination
```

## Validation

- `node --experimental-strip-types --test tests/rybbit-cta.test.ts` — 3 passed
- targeted TypeScript check for helper and tests — passed
- Prettier check for all changed files — passed
- `git diff --check` — passed

A full repository `next build` was previously exercised and exceeded the local 10-minute execution window during optimized production compilation; it produced no compile error before timeout.
