### PR TITLE
fix(pricing): clarify plan offers and Railway billing

### DIFF
--- a/app/[lang]/(home)/comparison/[slug]/sections/CostComparisonSection.tsx
+++ b/app/[lang]/(home)/comparison/[slug]/sections/CostComparisonSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { InfoIcon, TrendingDown, WebcamIcon } from 'lucide-react';
+import { ExternalLink, InfoIcon, TrendingDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ComparisonConfig, COSTS, type CostRow } from '../../config/platforms';
 
@@ -15,25 +15,32 @@ interface PlatformCostProps {
   name: string;
   costData?: CostRow;
   percentage: number;
-  isHigher: boolean;
 }
 
-function PlatformCost({
-  icon,
-  name,
-  costData,
-  percentage,
-  isHigher,
-}: PlatformCostProps) {
+function PlatformCost({ icon, name, costData, percentage }: PlatformCostProps) {
+  const isSealos = name.toLowerCase() === 'sealos';
+
   return (
-    <div className="grid grid-cols-[minmax(7rem,auto)_1fr_auto] items-center gap-3">
-      <div className="flex min-w-0 items-center gap-2">
+    <div className="grid grid-cols-[minmax(7.5rem,auto)_minmax(2rem,1fr)_auto] items-center gap-3">
+      <div className="flex min-w-0 items-center gap-2.5">
         <span className="flex size-5 shrink-0 items-center justify-center">
           {icon}
         </span>
-        <span className="truncate text-sm font-medium">{name}</span>
+        <div className="min-w-0">
+          <span className="block truncate text-sm font-medium">{name}</span>
+          <span
+            className={cn(
+              'mt-1 inline-block border px-1.5 py-0.5 text-[10px] leading-none',
+              isSealos
+                ? 'border-blue-400/25 bg-blue-400/10 text-blue-200'
+                : 'border-white/10 bg-white/5 text-zinc-400',
+            )}
+          >
+            {isSealos ? 'Fixed' : 'Estimate'}
+          </span>
+        </div>
       </div>
-      <div className="relative h-1.5 min-w-12 overflow-hidden rounded-full bg-zinc-800">
+      <div className="relative h-1.5 min-w-8 overflow-hidden bg-zinc-800">
         <div
           role="progressbar"
           aria-valuenow={Math.round(percentage)}
@@ -41,13 +48,13 @@ function PlatformCost({
           aria-valuemax={100}
           aria-label={`${name} cost: ${costData?.cost ?? 'unavailable'}, ${percentage.toFixed(0)}% of highest cost`}
           className={cn(
-            'absolute inset-y-0 left-0 rounded-full',
-            isHigher ? 'bg-zinc-500' : 'bg-blue-500',
+            'absolute inset-y-0 left-0',
+            isSealos ? 'bg-blue-500' : 'bg-zinc-500',
           )}
           style={{ width: `${Math.max(percentage, 2)}%` }}
         />
       </div>
-      <span className="min-w-20 text-right text-sm font-semibold">
+      <span className="min-w-20 text-right font-mono text-sm font-semibold tabular-nums">
         {costData?.cost ?? '—'}
       </span>
     </div>
@@ -65,18 +72,24 @@ export function CostComparisonSection({
 }: CostComparisonSectionProps) {
   return (
     <section className="container-compact pb-16 sm:pb-24">
-      <div className="mb-10">
-        <h2 className="mb-4 text-center text-2xl font-medium">{COSTS.title}</h2>
-        <p className="text-muted-foreground mx-auto max-w-3xl text-center">
+      <div className="mb-10 max-w-3xl">
+        <p className="mb-3 flex items-center gap-2 text-sm font-medium text-blue-400">
+          <span className="size-1.5 bg-blue-400" aria-hidden="true" />
+          Cost evidence
+        </p>
+        <h2 className="mb-4 text-2xl font-semibold sm:text-3xl">
+          {COSTS.title}
+        </h2>
+        <p className="text-muted-foreground max-w-3xl leading-7">
           {COSTS.description}
         </p>
       </div>
 
       <div className="hidden md:block">
-        <div className="grid grid-cols-[minmax(10rem,0.8fr)_minmax(22rem,1.6fr)_minmax(8rem,0.5fr)] border-y border-white/10 px-4 py-4 text-sm font-medium">
+        <div className="text-muted-foreground grid grid-cols-[minmax(10rem,0.75fr)_minmax(22rem,1.7fr)_minmax(9rem,0.55fr)] border-y border-white/10 px-4 py-4 text-xs font-medium">
           <span>Workload example</span>
           <span>Platform and monthly cost</span>
-          <span className="text-right">Difference</span>
+          <span className="text-right">Estimated difference</span>
         </div>
 
         {COSTS.rows.map((row, index) => {
@@ -92,7 +105,7 @@ export function CostComparisonSection({
           return (
             <div
               key={row.workload}
-              className="grid grid-cols-[minmax(10rem,0.8fr)_minmax(22rem,1.6fr)_minmax(8rem,0.5fr)] items-center border-b border-white/10 px-4 py-6"
+              className="grid grid-cols-[minmax(10rem,0.75fr)_minmax(22rem,1.7fr)_minmax(9rem,0.55fr)] items-center border-b border-white/10 px-4 py-7 transition-colors hover:bg-white/[0.02]"
             >
               <div>
                 <p className="text-sm font-medium">{row.workload}</p>
@@ -106,14 +119,12 @@ export function CostComparisonSection({
                   name={firstPlatform.name}
                   costData={firstCostData}
                   percentage={(firstCost / highestCost) * 100}
-                  isHigher={firstCost > secondCost}
                 />
                 <PlatformCost
                   icon={secondPlatform.icon}
                   name={secondPlatform.name}
                   costData={secondCostData}
                   percentage={(secondCost / highestCost) * 100}
-                  isHigher={secondCost > firstCost}
                 />
               </div>
               <div className="text-right">
@@ -127,7 +138,7 @@ export function CostComparisonSection({
                   <span
                     className={cn(
                       'inline-flex items-center gap-1 text-sm font-medium',
-                      savings > 0 ? 'text-green-500' : 'text-amber-400',
+                      savings > 0 ? 'text-blue-300' : 'text-zinc-300',
                     )}
                   >
                     {savings > 0 ? firstPlatform.name : secondPlatform.name}{' '}
@@ -155,7 +166,7 @@ export function CostComparisonSection({
           return (
             <article
               key={row.workload}
-              className="rounded-lg border border-white/10 bg-zinc-900 p-5"
+              className="rounded-lg border border-white/10 bg-white/[0.025] p-5"
             >
               <h3 className="font-medium">{row.workload}</h3>
               <p className="text-muted-foreground mt-1 text-sm">{row.specs}</p>
@@ -165,17 +176,22 @@ export function CostComparisonSection({
                   name={firstPlatform.name}
                   costData={firstCostData}
                   percentage={(firstCost / highestCost) * 100}
-                  isHigher={firstCost > secondCost}
                 />
                 <PlatformCost
                   icon={secondPlatform.icon}
                   name={secondPlatform.name}
                   costData={secondCostData}
                   percentage={(secondCost / highestCost) * 100}
-                  isHigher={secondCost > firstCost}
                 />
               </div>
-              <p className="mt-4 text-sm font-medium">
+              <p
+                className={cn(
+                  'mt-4 text-sm font-medium',
+                  savings !== null && savings > 0
+                    ? 'text-blue-300'
+                    : 'text-zinc-300',
+                )}
+              >
                 {savings === null
                   ? 'Cost comparison unavailable'
                   : savings === 0
@@ -203,14 +219,14 @@ export function CostComparisonSection({
         {(firstPlatform.content.costs.source ||
           secondPlatform.content.costs.source) && (
           <p className="text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
-            <WebcamIcon className="size-4 shrink-0" />
+            <ExternalLink className="size-4 shrink-0" />
             <span>Sources:</span>
             {firstPlatform.content.costs.source && (
               <a
                 href={firstPlatform.content.costs.source.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-foreground underline underline-offset-4"
+                className="text-foreground underline decoration-white/30 underline-offset-4 focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:outline-none"
               >
                 {firstPlatform.content.costs.source.label}
               </a>
@@ -222,7 +238,7 @@ export function CostComparisonSection({
                 href={secondPlatform.content.costs.source.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-foreground underline underline-offset-4"
+                className="text-foreground underline decoration-white/30 underline-offset-4 focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:outline-none"
               >
                 {secondPlatform.content.costs.source.label}
               </a>

--- a/app/[lang]/(home)/comparison/[slug]/sections/CostComparisonSection.tsx
+++ b/app/[lang]/(home)/comparison/[slug]/sections/CostComparisonSection.tsx
@@ -1,233 +1,228 @@
 'use client';
 
-import { ComparisonConfig, COSTS } from '../../config/platforms';
-import { TrendingDown, InfoIcon, WebcamIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { InfoIcon, TrendingDown, WebcamIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { ComparisonConfig, COSTS, type CostRow } from '../../config/platforms';
 
 interface CostComparisonSectionProps {
   firstPlatform: ComparisonConfig;
   secondPlatform: ComparisonConfig;
 }
 
+interface PlatformCostProps {
+  icon: ReactNode;
+  name: string;
+  costData?: CostRow;
+  percentage: number;
+  isHigher: boolean;
+}
+
+function PlatformCost({
+  icon,
+  name,
+  costData,
+  percentage,
+  isHigher,
+}: PlatformCostProps) {
+  return (
+    <div className="grid grid-cols-[minmax(7rem,auto)_1fr_auto] items-center gap-3">
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="flex size-5 shrink-0 items-center justify-center">
+          {icon}
+        </span>
+        <span className="truncate text-sm font-medium">{name}</span>
+      </div>
+      <div className="relative h-1.5 min-w-12 overflow-hidden rounded-full bg-zinc-800">
+        <div
+          role="progressbar"
+          aria-valuenow={Math.round(percentage)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`${name} cost: ${costData?.cost ?? 'unavailable'}, ${percentage.toFixed(0)}% of highest cost`}
+          className={cn(
+            'absolute inset-y-0 left-0 rounded-full',
+            isHigher ? 'bg-zinc-500' : 'bg-blue-500',
+          )}
+          style={{ width: `${Math.max(percentage, 2)}%` }}
+        />
+      </div>
+      <span className="min-w-20 text-right text-sm font-semibold">
+        {costData?.cost ?? '—'}
+      </span>
+    </div>
+  );
+}
+
+const parseCost = (cost: string): number => {
+  const match = cost.replaceAll(',', '').match(/\$(\d+(?:\.\d+)?)/);
+  return match ? Number(match[1]) : 0;
+};
+
 export function CostComparisonSection({
   firstPlatform,
   secondPlatform,
 }: CostComparisonSectionProps) {
-  // Extract numeric values from cost strings for visualization
-  const parseCost = (costStr: string): number => {
-    const match = costStr.match(/\$(\d+)/);
-    return match ? parseInt(match[1], 10) : 0;
-  };
-
   return (
     <section className="container-compact pb-16 sm:pb-24">
-      <div className="mb-12">
-        <h2 className="mb-6 text-center text-2xl font-medium">{COSTS.title}</h2>
-        <p className="text-muted-foreground">{COSTS.description}</p>
+      <div className="mb-10">
+        <h2 className="mb-4 text-center text-2xl font-medium">{COSTS.title}</h2>
+        <p className="text-muted-foreground mx-auto max-w-3xl text-center">
+          {COSTS.description}
+        </p>
       </div>
 
-      <div className="overflow-x-auto">
-        <table className="w-full min-w-[960px] border-collapse whitespace-nowrap">
-          <thead>
-            <tr className="text-primary border-y text-lg">
-              <th className="p-4 text-start font-normal">Workload Example</th>
-              <th className="p-4 text-start font-normal" colSpan={2}>
-                Cost Comparison
-              </th>
-              <th className="p-4 text-center font-normal">Savings</th>
-            </tr>
-          </thead>
-          <tbody>
-            {COSTS.rows.map((row, index) => {
-              const firstCostData = firstPlatform.content.costs.rows[index];
-              const secondCostData = secondPlatform.content.costs.rows[index];
+      <div className="hidden md:block">
+        <div className="grid grid-cols-[minmax(10rem,0.8fr)_minmax(22rem,1.6fr)_minmax(8rem,0.5fr)] border-y border-white/10 px-4 py-4 text-sm font-medium">
+          <span>Workload example</span>
+          <span>Platform and monthly cost</span>
+          <span className="text-right">Difference</span>
+        </div>
 
-              const firstCost = firstCostData?.cost || '';
-              const secondCost = secondCostData?.cost || '';
-              const firstCostNum = parseCost(firstCost);
-              const secondCostNum = parseCost(secondCost);
+        {COSTS.rows.map((row, index) => {
+          const firstCostData = firstPlatform.content.costs.rows[index];
+          const secondCostData = secondPlatform.content.costs.rows[index];
+          const firstCost = parseCost(firstCostData?.cost ?? '');
+          const secondCost = parseCost(secondCostData?.cost ?? '');
+          const highestCost = Math.max(firstCost, secondCost, 1);
+          const savingsData = secondCostData?.sealosSavings;
+          const savings =
+            savingsData?.type === 'comparable' ? savingsData.savings : null;
 
-              // Determine which price is higher
-              const higherCost = Math.max(firstCostNum, secondCostNum, 1);
-
-              // Calculate percentages: higher price = 100%, lower price = percentage of higher
-              const firstPercentage =
-                firstCostNum === higherCost
-                  ? 100
-                  : higherCost > 0
-                    ? (firstCostNum / higherCost) * 100
-                    : 0;
-              const secondPercentage =
-                secondCostNum === higherCost
-                  ? 100
-                  : higherCost > 0
-                    ? (secondCostNum / higherCost) * 100
-                    : 0;
-
-              // Determine which platform has higher price for gradient styling
-              // Price higher = gray gradient, price lower = blue gradient
-              const firstIsHigher = firstCostNum > secondCostNum;
-              const secondIsHigher = secondCostNum > firstCostNum;
-
-              // Get savings from sealosSavings in the row
-              const sealosSavingsData = secondCostData?.sealosSavings;
-
-              let savings: number | null = null;
-              let isInvalidComparison = false;
-
-              if (sealosSavingsData) {
-                if (sealosSavingsData.type === 'not-applicable') {
-                  isInvalidComparison = true;
-                } else if (sealosSavingsData.type === 'comparable') {
-                  savings = sealosSavingsData.savings;
-                }
-              }
-
-              return (
-                <tr key={row.workload} className={cn('border-b')}>
-                  <td className="w-[25%] px-4 py-6">
-                    <div className="flex flex-col gap-3">
-                      <div className="text-primary text-sm">{row.workload}</div>
-                      <div className="text-muted-foreground text-sm">
-                        {row.specs}
-                      </div>
-                    </div>
-                  </td>
-                  {/* Progress bars column */}
-                  <td className="w-[25%] px-4 py-6">
-                    <div className="flex flex-col gap-6">
-                      {/* First Platform Progress Bar */}
-                      <div className="flex items-center gap-4">
-                        <div className="relative flex-1">
-                          <div className="h-1.5 w-full rounded-full bg-zinc-800" />
-                          <div
-                            role="progressbar"
-                            aria-valuenow={firstPercentage}
-                            aria-valuemin={0}
-                            aria-valuemax={100}
-                            aria-label={`${firstPlatform.name} cost: ${firstCost}, ${firstPercentage.toFixed(0)}% of highest cost`}
-                            className={cn(
-                              'absolute top-0 h-1.5 rounded-full',
-                              firstIsHigher
-                                ? 'bg-gradient-to-r from-zinc-400 to-zinc-600'
-                                : 'bg-gradient-to-r from-white to-blue-600',
-                            )}
-                            style={{
-                              width: `${firstPercentage}%`,
-                            }}
-                          />
-                        </div>
-                      </div>
-
-                      {/* Second Platform Progress Bar */}
-                      <div className="flex items-center gap-4">
-                        <div className="relative flex-1">
-                          <div className="h-1.5 w-full rounded-full bg-zinc-800" />
-                          <div
-                            role="progressbar"
-                            aria-valuenow={secondPercentage}
-                            aria-valuemin={0}
-                            aria-valuemax={100}
-                            aria-label={`${secondPlatform.name} cost: ${secondCost}, ${secondPercentage.toFixed(0)}% of highest cost`}
-                            className={cn(
-                              'absolute top-0 h-1.5 rounded-full',
-                              secondIsHigher
-                                ? 'bg-gradient-to-r from-zinc-400 to-zinc-600'
-                                : 'bg-gradient-to-r from-white to-blue-600',
-                            )}
-                            style={{
-                              width: `${secondPercentage}%`,
-                            }}
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </td>
-
-                  {/* Labels and costs column */}
-                  <td className="w-[30%] px-4 py-6">
-                    <div className="flex flex-col gap-3">
-                      {/* First Platform Info */}
-                      <div className="flex items-center gap-2">
-                        <span className="text-primary text-sm">
-                          {firstCost}
-                        </span>
-                        <span className="text-muted-foreground text-sm">
-                          | {firstCostData?.label || firstPlatform.name}
-                        </span>
-                      </div>
-
-                      {/* Second Platform Info */}
-                      <div className="flex items-center gap-2">
-                        <span className="text-primary text-sm">
-                          {secondCost}
-                        </span>
-                        <span className="text-muted-foreground text-sm">
-                          | {secondCostData?.label || secondPlatform.name}
-                        </span>
-                      </div>
-                    </div>
-                  </td>
-
-                  <td className="w-[20%] px-4 py-6 text-center">
-                    {isInvalidComparison || savings === null ? (
-                      <span className="text-muted-foreground text-sm">-</span>
-                    ) : savings > 0 ? (
-                      <div className="flex items-center justify-center gap-1 text-green-500">
-                        <span className="text-sm">{savings}%</span>
-                        <TrendingDown className="size-3.5" />
-                      </div>
-                    ) : savings < 0 ? (
-                      <div className="flex items-center justify-center gap-1 text-red-500">
-                        <span className="text-sm">{savings}%</span>
-                      </div>
-                    ) : (
-                      <span className="text-muted-foreground text-sm">0%</span>
+          return (
+            <div
+              key={row.workload}
+              className="grid grid-cols-[minmax(10rem,0.8fr)_minmax(22rem,1.6fr)_minmax(8rem,0.5fr)] items-center border-b border-white/10 px-4 py-6"
+            >
+              <div>
+                <p className="text-sm font-medium">{row.workload}</p>
+                <p className="text-muted-foreground mt-2 text-sm">
+                  {row.specs}
+                </p>
+              </div>
+              <div className="space-y-5 pr-8">
+                <PlatformCost
+                  icon={firstPlatform.icon}
+                  name={firstPlatform.name}
+                  costData={firstCostData}
+                  percentage={(firstCost / highestCost) * 100}
+                  isHigher={firstCost > secondCost}
+                />
+                <PlatformCost
+                  icon={secondPlatform.icon}
+                  name={secondPlatform.name}
+                  costData={secondCostData}
+                  percentage={(secondCost / highestCost) * 100}
+                  isHigher={secondCost > firstCost}
+                />
+              </div>
+              <div className="text-right">
+                {savings === null ? (
+                  <span className="text-muted-foreground text-sm">
+                    Not comparable
+                  </span>
+                ) : savings === 0 ? (
+                  <span className="text-muted-foreground text-sm">Equal</span>
+                ) : (
+                  <span
+                    className={cn(
+                      'inline-flex items-center gap-1 text-sm font-medium',
+                      savings > 0 ? 'text-green-500' : 'text-amber-400',
                     )}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+                  >
+                    {savings > 0 ? firstPlatform.name : secondPlatform.name}{' '}
+                    {Math.abs(savings)}% lower
+                    {savings > 0 && <TrendingDown className="size-3.5" />}
+                  </span>
+                )}
+              </div>
+            </div>
+          );
+        })}
       </div>
 
-      <div className="mt-6 space-y-2">
+      <div className="space-y-4 md:hidden">
+        {COSTS.rows.map((row, index) => {
+          const firstCostData = firstPlatform.content.costs.rows[index];
+          const secondCostData = secondPlatform.content.costs.rows[index];
+          const firstCost = parseCost(firstCostData?.cost ?? '');
+          const secondCost = parseCost(secondCostData?.cost ?? '');
+          const highestCost = Math.max(firstCost, secondCost, 1);
+          const savingsData = secondCostData?.sealosSavings;
+          const savings =
+            savingsData?.type === 'comparable' ? savingsData.savings : null;
+
+          return (
+            <article
+              key={row.workload}
+              className="rounded-lg border border-white/10 bg-zinc-900 p-5"
+            >
+              <h3 className="font-medium">{row.workload}</h3>
+              <p className="text-muted-foreground mt-1 text-sm">{row.specs}</p>
+              <div className="mt-5 space-y-5 border-y border-white/10 py-5">
+                <PlatformCost
+                  icon={firstPlatform.icon}
+                  name={firstPlatform.name}
+                  costData={firstCostData}
+                  percentage={(firstCost / highestCost) * 100}
+                  isHigher={firstCost > secondCost}
+                />
+                <PlatformCost
+                  icon={secondPlatform.icon}
+                  name={secondPlatform.name}
+                  costData={secondCostData}
+                  percentage={(secondCost / highestCost) * 100}
+                  isHigher={secondCost > firstCost}
+                />
+              </div>
+              <p className="mt-4 text-sm font-medium">
+                {savings === null
+                  ? 'Cost comparison unavailable'
+                  : savings === 0
+                    ? 'Equal estimated monthly cost'
+                    : `${savings > 0 ? firstPlatform.name : secondPlatform.name} ${Math.abs(savings)}% lower`}
+              </p>
+            </article>
+          );
+        })}
+      </div>
+
+      <div className="mt-6 space-y-3">
         {firstPlatform.content.costs.note && (
-          <p className="text-muted-foreground flex items-center gap-1 text-xs">
-            <InfoIcon size={16} />
+          <p className="text-muted-foreground flex items-start gap-2 text-xs leading-5">
+            <InfoIcon className="mt-0.5 size-4 shrink-0" />
             {firstPlatform.content.costs.note}
           </p>
         )}
         {secondPlatform.content.costs.note && (
-          <p className="text-muted-foreground flex items-center gap-1 text-xs">
-            <InfoIcon size={16} />
+          <p className="text-muted-foreground flex items-start gap-2 text-xs leading-5">
+            <InfoIcon className="mt-0.5 size-4 shrink-0" />
             {secondPlatform.content.costs.note}
           </p>
         )}
         {(firstPlatform.content.costs.source ||
           secondPlatform.content.costs.source) && (
-          <p className="text-muted-foreground mt-2 flex items-center gap-1 text-xs">
-            <WebcamIcon size={16} />
-            Sources:{' '}
+          <p className="text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+            <WebcamIcon className="size-4 shrink-0" />
+            <span>Sources:</span>
             {firstPlatform.content.costs.source && (
               <a
                 href={firstPlatform.content.costs.source.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="underline"
+                className="text-foreground underline underline-offset-4"
               >
                 {firstPlatform.content.costs.source.label}
               </a>
             )}
             {firstPlatform.content.costs.source &&
-              secondPlatform.content.costs.source && <> | </>}
+              secondPlatform.content.costs.source && <span>·</span>}
             {secondPlatform.content.costs.source && (
               <a
                 href={secondPlatform.content.costs.source.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="underline"
+                className="text-foreground underline underline-offset-4"
               >
                 {secondPlatform.content.costs.source.label}
               </a>

--- a/app/[lang]/(home)/comparison/config/faqs.ts
+++ b/app/[lang]/(home)/comparison/config/faqs.ts
@@ -1,3 +1,11 @@
+import { railwayComparablePlans } from '../../pricing/config/plans';
+import {
+  RAILWAY_RATE_CARD,
+  calculateCostDifference,
+  estimateRailwayMonthlyCost,
+  formatUsd,
+} from '../../pricing/config/railway-cost';
+
 export type FAQ = {
   question: string;
   answer: string;
@@ -697,22 +705,36 @@ This is a key difference from Google App Engine, which runs only on GCP infrastr
   }
 
   // Railway-specific FAQs (default)
+  const standardPlan = railwayComparablePlans.find(
+    (plan) => plan.planId === 'standard',
+  )!;
+  const railwayMediumEstimate = estimateRailwayMonthlyCost({
+    averageVcpu: 8,
+    averageRamGb: 16,
+    volumeGb: 50,
+    egressGb: 100,
+  });
+  const railwayMediumDifference = calculateCostDifference(
+    standardPlan.monthlyPrice,
+    railwayMediumEstimate.total,
+  );
+
   return [
     {
       question:
         'How much can I actually save by switching from Railway to Sealos?',
-      answer: `For always-on production workloads, savings typically range from **60-70%**.
+      answer: `For this full-utilization medium workload, the Sealos Standard plan is about **${railwayMediumDifference.percentage}% lower** than the Railway estimate.
 
 **Example calculation for a medium app (8 vCPU, 16GB RAM, 24/7):**
 
 | Cost Component | Railway | Sealos Standard |
 |---------------|---------|-----------------|
-| Compute (monthly) | ~$300 | Included |
-| 50GB storage | $12.50 | Included |
-| 100GB egress | $5.00 | Included |
-| **Total** | **~$317/mo** | **~$128/mo** |
+| Compute (monthly) | ${formatUsd(railwayMediumEstimate.cpu + railwayMediumEstimate.ram)} | Included |
+| 50GB volume | ${formatUsd(railwayMediumEstimate.volume)} | Included |
+| 100GB egress | ${formatUsd(railwayMediumEstimate.egress)} | Included |
+| **Total** | **~${formatUsd(railwayMediumEstimate.total)}/mo** | **${formatUsd(standardPlan.monthlyPrice)}/mo** |
 
-The more resources you use, the more you save. Railway's per-second billing is great for sporadic workloads, but for production apps running continuously, fixed plans win.`,
+This is a rate-card estimate. Low-utilization workloads can cost less on Railway. Railway also provides hard usage limits that shut down workloads at the selected limit.`,
     },
     {
       question: "What's included in Sealos that costs extra on Railway?",
@@ -730,7 +752,8 @@ The more resources you use, the more you save. Railway's per-second billing is g
       question: 'Can I verify these claims myself?',
       answer: `Absolutely. All data in this comparison comes from official, publicly available sources:
 
-- **Railway Pricing**: [railway.com/pricing](https://railway.com/pricing)
+- **Railway Pricing**: [docs.railway.com/pricing/plans](${RAILWAY_RATE_CARD.sourceUrl})
+- **Railway Cost Controls**: [docs.railway.com/pricing/cost-control](${RAILWAY_RATE_CARD.costControlUrl})
 - **Sealos Pricing**: [sealos.io/pricing](https://sealos.io/pricing)
 - **Sealos Source Code**: [github.com/labring/sealos](https://github.com/labring/sealos)
 

--- a/app/[lang]/(home)/comparison/config/platforms.tsx
+++ b/app/[lang]/(home)/comparison/config/platforms.tsx
@@ -266,9 +266,9 @@ export type PlatformDimensionData = {
 };
 
 export const COSTS = {
-  title: 'Why Teams Switch: The Cost Reality Check',
+  title: 'Monthly Cost Examples: Plans vs. Usage Billing',
   description:
-    "For production workloads running 24/7 usage-based billing adds up fast. Here's a transparent comparison using publicly available pricing data.",
+    'Estimates use the listed average CPU and RAM for a 30-day month. Storage and egress are excluded unless a platform note says otherwise.',
   rows: [
     {
       workload: 'Small API',

--- a/app/[lang]/(home)/comparison/config/railway.tsx
+++ b/app/[lang]/(home)/comparison/config/railway.tsx
@@ -68,7 +68,7 @@ export const railwayConfig: ComparisonConfig = {
     overview:
       'Railway is a managed Platform-as-a-Service (PaaS) that simplifies application deployment through Git integration and usage-based billing. It automates builds and deploys for web services, background workers, Cron Jobs, and databases. Railway provides a fast path from code to production with automatic scaling (including scale-to-zero), abstracting away infrastructure complexity for individual developers and small teams.',
     pricing: `Railway Usage-Based Rates:
-• Hobby minimum usage: $5/month, counted toward resource usage
+• Hobby subscription: $${RAILWAY_RATE_CARD.hobbyMonthlySubscription}/month, including $${RAILWAY_RATE_CARD.hobbyIncludedUsage} of resource usage
 • CPU: $${RAILWAY_RATE_CARD.cpuPerVcpuMonth}/vCPU-month
 • Memory: $${RAILWAY_RATE_CARD.ramPerGbMonth}/GB-month
 • Egress: $${RAILWAY_RATE_CARD.egressPerGb}/GB
@@ -330,7 +330,7 @@ export const railwayConfig: ComparisonConfig = {
       {
         icon: <Clock className="size-full" />,
         content:
-          'Run mostly **stateless, low-traffic hobby projects** under $5/month',
+          "Run mostly **stateless, low-traffic hobby projects** near Railway's $5 Hobby minimum",
       },
       {
         icon: <CodeXml className="size-full" />,

--- a/app/[lang]/(home)/comparison/config/railway.tsx
+++ b/app/[lang]/(home)/comparison/config/railway.tsx
@@ -21,6 +21,44 @@ import {
   DollarSign,
 } from 'lucide-react';
 import { ComparisonConfig } from './platforms';
+import {
+  RAILWAY_RATE_CARD,
+  calculateCostDifference,
+  estimateRailwayMonthlyCost,
+  formatUsd,
+} from '../../pricing/config/railway-cost';
+import { railwayComparablePlans } from '../../pricing/config/plans';
+
+const railwayWorkloadInputs = [
+  { averageVcpu: 2, averageRamGb: 4, volumeGb: 0, egressGb: 0 },
+  { averageVcpu: 8, averageRamGb: 16, volumeGb: 0, egressGb: 0 },
+  { averageVcpu: 16, averageRamGb: 32, volumeGb: 0, egressGb: 0 },
+] as const;
+
+const comparableSealosPrices = ['hobby', 'standard', 'pro'].map(
+  (planId) =>
+    railwayComparablePlans.find((plan) => plan.planId === planId)!.monthlyPrice,
+);
+
+const railwayCostRows = railwayWorkloadInputs.map((input, index) => {
+  const estimate = estimateRailwayMonthlyCost(input);
+  const difference = calculateCostDifference(
+    comparableSealosPrices[index],
+    estimate.total,
+  );
+
+  return {
+    cost: `~${formatUsd(estimate.total)}/mo`,
+    sealosSavings: {
+      type: 'comparable' as const,
+      savings:
+        difference.lowerCost === 'sealos'
+          ? difference.percentage
+          : -difference.percentage,
+    },
+    label: 'Railway usage estimate',
+  };
+});
 
 export const railwayConfig: ComparisonConfig = {
   name: 'Railway',
@@ -30,11 +68,11 @@ export const railwayConfig: ComparisonConfig = {
     overview:
       'Railway is a managed Platform-as-a-Service (PaaS) that simplifies application deployment through Git integration and usage-based billing. It automates builds and deploys for web services, background workers, Cron Jobs, and databases. Railway provides a fast path from code to production with automatic scaling (including scale-to-zero), abstracting away infrastructure complexity for individual developers and small teams.',
     pricing: `Railway Usage-Based Rates:
-• CPU: $0.000463/vCPU-minute (~$0.028/vCPU-hour)
-• Memory: $0.000231/GB-minute (~$0.014/GB-hour)
-• Egress: $0.05/GB
-• Storage: $0.25/GB-month
-• Object Storage: $0.015/GB-month`,
+• Hobby minimum usage: $5/month, counted toward resource usage
+• CPU: $${RAILWAY_RATE_CARD.cpuPerVcpuMonth}/vCPU-month
+• Memory: $${RAILWAY_RATE_CARD.ramPerGbMonth}/GB-month
+• Egress: $${RAILWAY_RATE_CARD.egressPerGb}/GB
+• Volume storage: $${RAILWAY_RATE_CARD.volumePerGbMonth}/GB-month`,
     dimensions: {
       overview: {
         features: [
@@ -262,27 +300,11 @@ export const railwayConfig: ComparisonConfig = {
       },
     },
     costs: {
-      rows: [
-        {
-          cost: '~$90/mo',
-          sealosSavings: { type: 'comparable', savings: 72 }, // $25 vs $90，节省 72%
-          label: 'Railway (Usage-Based)',
-        },
-        {
-          cost: '~$320/mo',
-          sealosSavings: { type: 'comparable', savings: 60 }, // $128 vs $320，节省 60%
-          label: 'Railway (Usage-Based)',
-        },
-        {
-          cost: '~$640/mo',
-          sealosSavings: { type: 'comparable', savings: 20 }, // $512 vs $640，节省 20%
-          label: 'Railway (Usage-Based)',
-        },
-      ],
-      note: 'Railway calculation: $0.000463/vCPU-min + $0.000231/GB-min = 43,200 min/month',
+      rows: railwayCostRows,
+      note: `Estimate uses $${RAILWAY_RATE_CARD.cpuPerVcpuMonth}/vCPU-month and $${RAILWAY_RATE_CARD.ramPerGbMonth}/GB-month at the listed average usage. Volume and egress are excluded from these three examples. Verified ${RAILWAY_RATE_CARD.verifiedAt}.`,
       source: {
-        url: 'https://railway.com/pricing',
-        label: 'Railway Pricing',
+        url: RAILWAY_RATE_CARD.sourceUrl,
+        label: 'Railway pricing documentation',
       },
     },
     guidance: [

--- a/app/[lang]/(home)/comparison/config/sealos.tsx
+++ b/app/[lang]/(home)/comparison/config/sealos.tsx
@@ -15,6 +15,18 @@ import {
   TrendingUp,
 } from 'lucide-react';
 import { ComparisonConfig } from './platforms';
+import { railwayComparablePlans } from '../../pricing/config/plans';
+
+const sealosPricingSummary = railwayComparablePlans
+  .map(
+    (plan) =>
+      `• ${plan.name}: ${plan.price}/mo → ${plan.resources.cpu} vCPU, ${plan.resources.ram}GB RAM, ${plan.resources.disk}GB disk, ${plan.resources.traffic >= 1000 ? `${plan.resources.traffic / 1000}TB` : `${plan.resources.traffic}GB`} traffic`,
+  )
+  .join('\n');
+
+const sealosComparisonCostPlans = ['hobby', 'standard', 'pro'].map(
+  (planId) => railwayComparablePlans.find((plan) => plan.planId === planId)!,
+);
 
 export const sealosConfig: ComparisonConfig = {
   name: 'Sealos',
@@ -23,10 +35,8 @@ export const sealosConfig: ComparisonConfig = {
   content: {
     overview:
       'Sealos is an AI-native Cloud Operating System built on Kubernetes that unifies the entire application lifecycle, from development in Cloud Development Environments (CDEs) to production deployment and management. It is perfect for building and scaling modern AI applications, SaaS platforms, managed databases (MySQL, PostgreSQL, Redis, MongoDB) and complex microservice architectures. The platform is 100% source-available, and for production you can choose either a fully managed cloud service or self-host on your own infrastructure.',
-    pricing: `Sealos Fixed Plans (All-Inclusive):
-• Hobby: $25/mo → 4 vCPU, 4GB RAM, 30GB disk, 50GB traffic
-• Standard: $128/mo → 8 vCPU, 8GB RAM, 50GB disk, 300GB traffic
-• Pro: $512/mo → 16 vCPU, 32GB RAM, 200GB disk, 1TB traffic
+    pricing: `Sealos Monthly Resource Plans:
+${sealosPricingSummary}
 • 7-day free trial with 4 vCPU + 4GB (no credit card required)`,
     dimensions: {
       overview: {
@@ -213,20 +223,11 @@ export const sealosConfig: ComparisonConfig = {
       },
     },
     costs: {
-      rows: [
-        {
-          cost: '~$25/mo (Hobby)',
-          label: 'Sealos (Fixed Plan)',
-        },
-        {
-          cost: '~$128/mo (Standard)',
-          label: 'Sealos (Fixed Plan)',
-        },
-        {
-          cost: '~$512/mo (Pro)',
-          label: 'Sealos (Fixed Plan)',
-        },
-      ],
+      rows: sealosComparisonCostPlans.map((plan) => ({
+        cost: `${plan.price}/mo`,
+        label: `Sealos ${plan.name} plan`,
+      })),
+      note: 'Plan prices include the resource package listed on the Sealos pricing page.',
       source: {
         url: 'https://sealos.io/pricing',
         label: 'Sealos Pricing',

--- a/app/[lang]/(home)/pricing/components/FAQSection.tsx
+++ b/app/[lang]/(home)/pricing/components/FAQSection.tsx
@@ -6,7 +6,6 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/accordion';
-import { GradientText } from '@/new-components/GradientText';
 import { cn } from '@/lib/utils';
 import { faqItems } from '../config/faqs';
 
@@ -18,20 +17,24 @@ export function FAQSection({ className }: FAQSectionProps) {
   return (
     <section
       className={cn(
-        'container flex flex-col items-center gap-16 py-18',
+        'container grid gap-12 py-20 lg:grid-cols-[0.65fr_1.35fr] lg:gap-20 lg:py-28',
         className,
       )}
     >
-      <div className="flex flex-col items-center gap-6">
-        <h2 className="text-center text-4xl font-semibold">
-          <GradientText>Pricing questions</GradientText>
+      <div className="lg:sticky lg:top-28 lg:self-start">
+        <p className="flex items-center gap-2 text-sm font-medium text-blue-400">
+          <span className="size-1.5 bg-blue-400" aria-hidden="true" />
+          Pricing FAQ
+        </p>
+        <h2 className="mt-3 text-3xl font-semibold text-balance sm:text-4xl">
+          Questions before you choose a plan
         </h2>
-        <p className="text-muted-foreground w-full max-w-2xl text-center text-base">
+        <p className="text-muted-foreground mt-5 max-w-sm text-base leading-7 text-pretty">
           Plan limits, billing boundaries, upgrades, and payment details.
         </p>
       </div>
 
-      <div className="w-full max-w-4xl">
+      <div className="w-full">
         <Accordion
           type="single"
           defaultValue="item-0"
@@ -44,11 +47,16 @@ export function FAQSection({ className }: FAQSectionProps) {
               value={`item-${index}`}
               className="border-b border-white/15"
             >
-              <AccordionTrigger className="text-foreground [&>svg]:text-muted-foreground px-0 py-8 text-left text-lg font-normal hover:no-underline [&>svg]:size-6">
-                {item.question}
+              <AccordionTrigger className="text-foreground [&>svg]:text-muted-foreground gap-5 px-0 py-7 text-left text-base font-medium hover:no-underline focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-4 focus-visible:ring-offset-zinc-950 sm:text-lg [&>svg]:size-5">
+                <span className="flex items-baseline gap-4">
+                  <span className="text-muted-foreground text-xs font-normal tabular-nums">
+                    {String(index + 1).padStart(2, '0')}
+                  </span>
+                  <span>{item.question}</span>
+                </span>
               </AccordionTrigger>
               {item.answer && (
-                <AccordionContent className="text-muted-foreground pr-0 pb-8 pl-0 text-sm">
+                <AccordionContent className="text-muted-foreground pr-0 pb-8 pl-9 text-sm leading-7">
                   {item.answer}
                 </AccordionContent>
               )}

--- a/app/[lang]/(home)/pricing/components/FAQSection.tsx
+++ b/app/[lang]/(home)/pricing/components/FAQSection.tsx
@@ -24,10 +24,10 @@ export function FAQSection({ className }: FAQSectionProps) {
     >
       <div className="flex flex-col items-center gap-6">
         <h2 className="text-center text-4xl font-semibold">
-          <GradientText>Got Questions?</GradientText>
+          <GradientText>Pricing questions</GradientText>
         </h2>
         <p className="text-muted-foreground w-full max-w-2xl text-center text-base">
-          Everything you need to know about Sealos pricing
+          Plan limits, billing boundaries, upgrades, and payment details.
         </p>
       </div>
 

--- a/app/[lang]/(home)/pricing/components/FeaturesSection.tsx
+++ b/app/[lang]/(home)/pricing/components/FeaturesSection.tsx
@@ -21,13 +21,13 @@ export function FeaturesSection({ className }: FeaturesSectionProps) {
           <div className="max-w-md">
             <p className="flex items-center gap-2 text-sm font-medium text-blue-400">
               <span className="size-1.5 bg-blue-400" aria-hidden="true" />
-              Included with every paid plan
+              Available on every paid plan
             </p>
             <h2 className="mt-3 text-2xl font-semibold text-balance">
-              One platform for running your apps
+              Deploy apps, databases, and storage from one platform
             </h2>
             <p className="text-muted-foreground mt-3 text-sm leading-6">
-              Availability follows the resource limits shown on each plan.
+              These services use the resources included in your plan.
             </p>
           </div>
 

--- a/app/[lang]/(home)/pricing/components/FeaturesSection.tsx
+++ b/app/[lang]/(home)/pricing/components/FeaturesSection.tsx
@@ -1,20 +1,12 @@
-import {
-  Boxes,
-  Database,
-  Globe2,
-  HardDrive,
-  LayoutGrid,
-  Server,
-} from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const includedCapabilities = [
-  { icon: Server, label: 'Application deployment' },
-  { icon: Database, label: 'Managed databases' },
-  { icon: HardDrive, label: 'S3-compatible storage' },
-  { icon: Globe2, label: 'Custom domains and SSL' },
-  { icon: LayoutGrid, label: 'App Store templates' },
-  { icon: Boxes, label: 'Kubernetes-native infrastructure' },
+  'Application deployment',
+  'Managed databases',
+  'S3-compatible storage',
+  'Custom domains and SSL',
+  'App Store templates',
+  'Kubernetes-native infrastructure',
 ];
 
 interface FeaturesSectionProps {
@@ -23,29 +15,36 @@ interface FeaturesSectionProps {
 
 export function FeaturesSection({ className }: FeaturesSectionProps) {
   return (
-    <section className={cn('border-y border-white/10 py-14', className)}>
+    <section className={cn('border-y border-white/10 py-16', className)}>
       <div className="container">
-        <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
-          <div className="max-w-sm">
-            <p className="text-sm font-medium text-blue-400">
+        <div className="grid gap-10 lg:grid-cols-[0.75fr_1.25fr] lg:items-center lg:gap-16">
+          <div className="max-w-md">
+            <p className="flex items-center gap-2 text-sm font-medium text-blue-400">
+              <span className="size-1.5 bg-blue-400" aria-hidden="true" />
               Included with every paid plan
             </p>
-            <h2 className="mt-3 text-2xl font-semibold">
+            <h2 className="mt-3 text-2xl font-semibold text-balance">
               One platform for running your apps
             </h2>
-            <p className="text-muted-foreground mt-3 text-sm">
+            <p className="text-muted-foreground mt-3 text-sm leading-6">
               Availability follows the resource limits shown on each plan.
             </p>
           </div>
 
-          <div className="grid flex-1 grid-cols-1 gap-x-8 gap-y-5 sm:grid-cols-2 lg:max-w-3xl lg:grid-cols-3">
-            {includedCapabilities.map(({ icon: Icon, label }) => (
-              <div key={label} className="flex items-center gap-3">
-                <Icon className="size-5 shrink-0 text-blue-400" />
-                <span className="text-sm font-medium">{label}</span>
-              </div>
+          <ul className="grid grid-cols-1 border-t border-white/10 sm:grid-cols-2">
+            {includedCapabilities.map((label, index) => (
+              <li
+                key={label}
+                className={cn(
+                  'flex items-center gap-3 border-b border-white/10 py-4 text-sm font-medium',
+                  index % 2 === 0 ? 'sm:pr-6' : 'sm:border-l sm:pl-6',
+                )}
+              >
+                <span className="size-1.5 shrink-0 bg-blue-400" />
+                {label}
+              </li>
             ))}
-          </div>
+          </ul>
         </div>
       </div>
     </section>

--- a/app/[lang]/(home)/pricing/components/FeaturesSection.tsx
+++ b/app/[lang]/(home)/pricing/components/FeaturesSection.tsx
@@ -1,208 +1,52 @@
-import Image from 'next/image';
-import { GradientText } from '@/new-components/GradientText';
-import { cn } from '@/lib/utils';
 import {
-  CodeXml,
-  LayoutGrid,
+  Boxes,
   Database,
-  Cpu,
-  Box,
-  Bot,
+  Globe2,
+  HardDrive,
+  LayoutGrid,
+  Server,
 } from 'lucide-react';
-import { GradientLucideIcon } from '@/new-components/GradientLucideIcon';
+import { cn } from '@/lib/utils';
 
-const GradientCodeXml = (props: { className?: string }) => (
-  <GradientLucideIcon Icon={CodeXml} {...props} />
-);
-const GradientLayoutGrid = (props: { className?: string }) => (
-  <GradientLucideIcon Icon={LayoutGrid} {...props} />
-);
-const GradientDatabaseIcon = (props: { className?: string }) => (
-  <GradientLucideIcon Icon={Database} {...props} />
-);
-const GradientCpu = (props: { className?: string }) => (
-  <GradientLucideIcon Icon={Cpu} {...props} />
-);
-const GradientBox = (props: { className?: string }) => (
-  <GradientLucideIcon Icon={Box} {...props} />
-);
-const GradientBotIcon = (props: { className?: string }) => (
-  <GradientLucideIcon Icon={Bot} {...props} />
-);
-import CloudIDEImage from '../assets/card-cloudide.svg';
-import AppStoreImage from '../assets/card-appstore.svg';
-import DBStorageImage from '../assets/card-dbstor.svg';
-import K8sImage from '../assets/card-k8s.svg';
-import MultiTenancyImage from '../assets/card-multitenancy.svg';
-import AINativeImage from '../assets/card-ainative.svg';
-
-interface FeatureCardProps {
-  icon: React.ComponentType<{ className?: string }>;
-  title: string;
-  description: string;
-  children?: React.ReactNode;
-  className?: string;
-}
-
-function FeatureCard({
-  icon: Icon,
-  title,
-  description,
-  children,
-  className,
-}: FeatureCardProps) {
-  return (
-    <div
-      className={cn(
-        'bg-card flex flex-col justify-start gap-5 rounded-xl border p-8',
-        className,
-      )}
-    >
-      <div className="flex size-fit grow-0 items-center justify-center rounded-full border bg-white/5 p-4">
-        <Icon className="size-5" />
-      </div>
-      <div className="flex flex-col gap-3">
-        <h3 className="text-foreground text-xl font-medium">{title}</h3>
-        <p className="text-muted-foreground text-sm whitespace-pre-wrap">
-          {description}
-        </p>
-      </div>
-      {children && (
-        <div className="relative w-full flex-1 overflow-hidden">
-          <div className="relative aspect-[12/5] w-full">{children}</div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-interface FeatureData {
-  icon: React.ComponentType<{ className?: string }>;
-  title: string;
-  description: string;
-  image?: React.ReactNode;
-}
-
-const features: FeatureData[] = [
-  {
-    icon: GradientCodeXml,
-    title: 'Integrated Cloud IDEs',
-    description:
-      'Zero-setup, collaborative development in the cloud. Eliminate local environment inconsistencies with DevBox.',
-    image: (
-      <Image
-        src={CloudIDEImage}
-        alt="Integrated Cloud IDEs"
-        className="h-full w-full object-contain"
-        fill
-      />
-    ),
-  },
-  {
-    icon: GradientLayoutGrid,
-    title: 'Extensive App Store',
-    description:
-      'Deploy complex applications with a single click. No YAML configuration, no container orchestration complexity - just point, click, and deploy.',
-    image: (
-      <Image
-        src={AppStoreImage}
-        alt="Extensive App Store"
-        className="h-full w-full object-contain"
-        fill
-      />
-    ),
-  },
-  {
-    icon: GradientDatabaseIcon,
-    title: 'Managed Databases & Storage',
-    description:
-      'Production-ready PostgreSQL, MySQL, MongoDB, Redis, and built-in S3-compatible Object Storage.',
-    image: (
-      <Image
-        src={DBStorageImage}
-        alt="Managed Databases & Storage"
-        className="h-full w-full object-contain"
-        fill
-      />
-    ),
-  },
-  {
-    icon: GradientCpu,
-    title: 'Full Kubernetes Power',
-    description:
-      'Access the full power of Kubernetes without the complexity. K8s-native from day one.',
-    image: (
-      <Image
-        src={K8sImage}
-        alt="Full Kubernetes Power"
-        className="h-full w-full object-contain"
-        fill
-      />
-    ),
-  },
-  {
-    icon: GradientBox,
-    title: 'Enterprise Multi-Tenancy',
-    description:
-      'Workspace-based isolation with granular RBAC and per-workspace resource quotas for secure collaboration.',
-    image: (
-      <Image
-        src={MultiTenancyImage}
-        alt="Enterprise Multi-Tenancy"
-        className="h-full w-full object-contain"
-        fill
-      />
-    ),
-  },
-  {
-    icon: GradientBotIcon,
-    title: 'AI-Native Infrastructure',
-    description:
-      'Build and scale modern AI applications, SaaS platforms, and complex microservice architectures with AI simply by describing them.',
-    image: (
-      <Image
-        src={AINativeImage}
-        alt="AI-Native Infrastructure"
-        className="h-full w-full object-contain"
-        fill
-      />
-    ),
-  },
+const includedCapabilities = [
+  { icon: Server, label: 'Application deployment' },
+  { icon: Database, label: 'Managed databases' },
+  { icon: HardDrive, label: 'S3-compatible storage' },
+  { icon: Globe2, label: 'Custom domains and SSL' },
+  { icon: LayoutGrid, label: 'App Store templates' },
+  { icon: Boxes, label: 'Kubernetes-native infrastructure' },
 ];
 
 interface FeaturesSectionProps {
   className?: string;
-  featureImages?: React.ReactNode[];
 }
 
-export function FeaturesSection({
-  className,
-  featureImages = [],
-}: FeaturesSectionProps) {
+export function FeaturesSection({ className }: FeaturesSectionProps) {
   return (
-    <section className={cn('container py-18', className)}>
-      <div className="mb-16 flex flex-col items-center gap-6">
-        <h2 className="text-center text-4xl font-semibold">
-          <span>Everything You Need to </span>
-          <GradientText>Build and Scale</GradientText>
-        </h2>
-        <p className="text-muted-foreground w-full max-w-2xl text-center text-base">
-          Unify the entire application lifecycle, from development in cloud IDEs
-          to production deployment and management.
-        </p>
-      </div>
+    <section className={cn('border-y border-white/10 py-14', className)}>
+      <div className="container">
+        <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+          <div className="max-w-sm">
+            <p className="text-sm font-medium text-blue-400">
+              Included with every paid plan
+            </p>
+            <h2 className="mt-3 text-2xl font-semibold">
+              One platform for running your apps
+            </h2>
+            <p className="text-muted-foreground mt-3 text-sm">
+              Availability follows the resource limits shown on each plan.
+            </p>
+          </div>
 
-      <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
-        {features.map((feature, index) => (
-          <FeatureCard
-            key={index}
-            icon={feature.icon}
-            title={feature.title}
-            description={feature.description}
-          >
-            {featureImages[index] || feature.image}
-          </FeatureCard>
-        ))}
+          <div className="grid flex-1 grid-cols-1 gap-x-8 gap-y-5 sm:grid-cols-2 lg:max-w-3xl lg:grid-cols-3">
+            {includedCapabilities.map(({ icon: Icon, label }) => (
+              <div key={label} className="flex items-center gap-3">
+                <Icon className="size-5 shrink-0 text-blue-400" />
+                <span className="text-sm font-medium">{label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/app/[lang]/(home)/pricing/components/FreeTrialCard.tsx
+++ b/app/[lang]/(home)/pricing/components/FreeTrialCard.tsx
@@ -2,9 +2,6 @@
 
 import { Button } from '@/components/ui/button';
 import { ArrowRight } from 'lucide-react';
-import { AiAgentStar } from '@/new-components/AiAgentStar';
-import { GradientText } from '@/new-components/GradientText';
-import { FeatureItem } from './FeatureItem';
 import { cn } from '@/lib/utils';
 import { useGTM } from '@/hooks/use-gtm';
 import { getRybbitCtaProps } from '@/lib/analytics/rybbit-cta';
@@ -40,35 +37,41 @@ export function FreeTrialCard({ className }: FreeTrialCardProps) {
   };
 
   return (
-    <div
+    <aside
       className={cn(
-        'flex w-full flex-row flex-wrap items-center rounded-xl border bg-zinc-900 p-7',
+        'grid w-full items-center gap-7 border-y border-white/10 py-6 lg:grid-cols-[0.9fr_1.65fr_auto] lg:gap-10',
         className,
       )}
     >
-      <div className="flex w-full flex-col gap-4 sm:w-2/3 xl:w-auto">
-        <div className="flex w-fit items-center gap-1 rounded-full border border-white/5 bg-white/5 px-3 py-1.5 text-sm backdrop-blur-sm">
-          <GradientText>New User Offer</GradientText>
-          <AiAgentStar className="size-1.5" />
-        </div>
-
-        <div className="flex max-w-md flex-col gap-3">
-          <div className="flex items-end gap-3">
-            <p className="text-foreground text-4xl font-bold">Free $0</p>
-          </div>
-          <p className="text-muted-foreground text-base whitespace-pre-wrap">
-            For individuals. Perfect for getting started and deploying small
-            apps on Sealos.
-          </p>
+      <div>
+        <p className="flex items-center gap-2 text-sm font-medium text-blue-400">
+          <span className="size-1.5 bg-blue-400" aria-hidden="true" />
+          Free trial
+        </p>
+        <div className="mt-2 flex items-end gap-3">
+          <p className="text-4xl font-semibold tabular-nums">$0</p>
+          <p className="text-muted-foreground pb-1 text-sm">for new users</p>
         </div>
       </div>
 
-      <div className="mx-10 mt-10 hidden h-[6rem] w-px shrink-0 items-center justify-center border-l xl:block" />
+      <dl className="grid grid-cols-2 gap-x-8 gap-y-5 sm:grid-cols-4">
+        {[
+          ['Duration', '7 days'],
+          ['Compute', '4 vCPU'],
+          ['Memory', '4GB RAM'],
+          ['AI credits', '100'],
+        ].map(([label, value]) => (
+          <div key={label}>
+            <dt className="text-muted-foreground text-xs">{label}</dt>
+            <dd className="mt-1 text-sm font-semibold tabular-nums">{value}</dd>
+          </div>
+        ))}
+      </dl>
 
-      <div className="mt-8 ml-auto flex w-full flex-col justify-center gap-3 sm:mt-0 sm:w-1/3 sm:max-w-2xs xl:order-4 xl:w-auto">
+      <div className="flex flex-col items-start gap-2 lg:items-end">
         <Button
           variant="landing-primary"
-          className="h-10 px-8"
+          className="h-10 rounded-md px-6 transition duration-200 active:translate-y-px motion-reduce:transition-none"
           {...getRybbitCtaProps({
             id: 'pricing_free_trial_start_deploying',
             location: 'pricing_free_trial_card',
@@ -76,24 +79,11 @@ export function FreeTrialCard({ className }: FreeTrialCardProps) {
           })}
           onClick={handleStartDeploying}
         >
-          <span>Start Deploying</span>
+          <span>Start free</span>
           <ArrowRight className="ml-2 size-4" />
         </Button>
-        <p className="text-muted-foreground text-sm whitespace-pre-wrap sm:text-center">
-          No credit card required
-        </p>
+        <p className="text-muted-foreground text-xs">No credit card required</p>
       </div>
-
-      <div className="my-4 h-px w-full shrink-0 items-center justify-center border-t xl:hidden" />
-
-      <div className="grid grow grid-cols-1 flex-col items-start gap-3 sm:grid-cols-2 sm:flex-row lg:grid-cols-3 xl:order-3 xl:mt-12 xl:grid-cols-2">
-        <FeatureItem text="Start with a 7-day free trial" />
-        <FeatureItem text="4 vCPU" />
-        <FeatureItem text="4GB RAM" />
-        <FeatureItem text="5 GB of volume storage" />
-        <FeatureItem text="500 MB included bandwidth" />
-        <FeatureItem text="100 AI Credits" />
-      </div>
-    </div>
+    </aside>
   );
 }

--- a/app/[lang]/(home)/pricing/components/FreeTrialCard.tsx
+++ b/app/[lang]/(home)/pricing/components/FreeTrialCard.tsx
@@ -54,11 +54,13 @@ export function FreeTrialCard({ className }: FreeTrialCardProps) {
         </div>
       </div>
 
-      <dl className="grid grid-cols-2 gap-x-8 gap-y-5 sm:grid-cols-4">
+      <dl className="grid grid-cols-2 gap-x-8 gap-y-5 sm:grid-cols-3">
         {[
           ['Duration', '7 days'],
           ['Compute', '4 vCPU'],
           ['Memory', '4GB RAM'],
+          ['Storage', '5GB'],
+          ['Bandwidth', '500MB'],
           ['AI credits', '100'],
         ].map(([label, value]) => (
           <div key={label}>

--- a/app/[lang]/(home)/pricing/components/FreeTrialCard.tsx
+++ b/app/[lang]/(home)/pricing/components/FreeTrialCard.tsx
@@ -17,7 +17,7 @@ const FREE_TRIAL_URL =
   'https://os.sealos.io/?openapp=system-costcenter?mode%3dcreate';
 
 export function FreeTrialCard({ className }: FreeTrialCardProps) {
-  const { trackButton } = useGTM();
+  const { trackButton, trackCustom } = useGTM();
 
   const handleStartDeploying = () => {
     trackButton(
@@ -30,8 +30,13 @@ export function FreeTrialCard({ className }: FreeTrialCardProps) {
         plan_price: '$0',
       },
     );
+    trackCustom('pricing_plan_selected', {
+      plan_id: 'free-trial',
+      plan_price: 0,
+      location: 'free_trial_card',
+    });
 
-    window.open(FREE_TRIAL_URL, '_blank');
+    window.open(FREE_TRIAL_URL, '_blank', 'noopener,noreferrer');
   };
 
   return (

--- a/app/[lang]/(home)/pricing/components/MorePlans.tsx
+++ b/app/[lang]/(home)/pricing/components/MorePlans.tsx
@@ -1,17 +1,10 @@
 'use client';
 
-import { useState } from 'react';
-import { Check, ChevronDown } from 'lucide-react';
+import { ArrowUpRight, GitCompare } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { cn } from '@/lib/utils';
 import { useAuthRedirect } from '@/hooks/use-auth-redirect';
 import { useGTM } from '@/hooks/use-gtm';
+import { cn } from '@/lib/utils';
 import { morePlans, type PricingPlan } from '../config/plans';
 import { getRybbitCtaProps, toRybbitCtaId } from '@/lib/analytics/rybbit-cta';
 
@@ -21,156 +14,103 @@ interface MorePlansProps {
 
 export function MorePlans({ className }: MorePlansProps) {
   const handleAuthRedirect = useAuthRedirect();
-  const { trackButton } = useGTM();
-  const [isMorePlansEnabled, setIsMorePlansEnabled] = useState(false);
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [selectedPlan, setSelectedPlan] = useState<PricingPlan>(morePlans[0]);
+  const { trackButton, trackCustom } = useGTM();
 
-  const handleGetStarted = () => {
-    const url =
-      selectedPlan.action.type === 'direct' ? selectedPlan.action.url : '';
-    trackButton(
-      'Get Started',
-      `pricing-more-plans-${selectedPlan.name.toLowerCase()}`,
-      'url',
-      url,
-      {
-        plan_name: selectedPlan.name,
-        plan_price: selectedPlan.price,
-      },
-    );
+  const handlePlanClick = (plan: PricingPlan) => {
+    const url = plan.action.type === 'direct' ? plan.action.url : '';
+    trackButton(plan.buttonText, `pricing-scale-${plan.planId}`, 'url', url, {
+      plan_id: plan.planId,
+      plan_name: plan.name,
+      plan_price: plan.monthlyPrice,
+    });
+    trackCustom('pricing_plan_selected', {
+      plan_id: plan.planId,
+      plan_price: plan.monthlyPrice,
+      location: 'scale_plan_card',
+    });
 
-    if (selectedPlan.action.type === 'auth') {
-      handleAuthRedirect(selectedPlan.action.params);
-    } else {
-      window.open(selectedPlan.action.url, '_blank');
+    if (plan.action.type === 'auth') {
+      handleAuthRedirect(plan.action.params);
+      return;
     }
+
+    window.open(plan.action.url, '_blank', 'noopener,noreferrer');
   };
 
-  const displayPlan = selectedPlan;
-
-  const handlePlanSelect = (plan: PricingPlan) => {
-    setSelectedPlan(plan);
-    setIsDropdownOpen(false);
+  const handleCompare = (plan: PricingPlan) => {
+    trackCustom('pricing_compare_plan_selected', {
+      plan_id: plan.planId,
+      location: 'scale_plan_card',
+    });
+    window.dispatchEvent(
+      new CustomEvent('pricing:compare-plan', {
+        detail: { planId: plan.planId },
+      }),
+    );
+    document
+      .getElementById('railway-cost')
+      ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 
   return (
-    <div
-      className={cn(
-        'flex w-full flex-col items-center gap-4 lg:flex-row',
-        className,
-      )}
-    >
-      <div className="flex w-full flex-1 flex-col items-start gap-4 overflow-hidden rounded-2xl border bg-zinc-900 px-4 py-3 lg:flex-row lg:items-center">
-        <label className="flex w-full shrink-0 items-center justify-start gap-2 lg:w-auto">
-          <button
-            onClick={() => setIsMorePlansEnabled(!isMorePlansEnabled)}
-            className={cn(
-              'border-primary bg-background pointer-events-none flex size-4 shrink-0 items-center justify-center rounded-sm border transition-colors',
-              isMorePlansEnabled && 'bg-primary',
-            )}
-          >
-            {isMorePlansEnabled && (
-              <Check className="text-primary-foreground size-3" />
-            )}
-          </button>
-          <p className="text-primary text-base font-normal whitespace-nowrap">
-            More Plans
-          </p>
-        </label>
-
-        <DropdownMenu
-          open={isMorePlansEnabled ? isDropdownOpen : false}
-          onOpenChange={(open) => {
-            if (isMorePlansEnabled) {
-              setIsDropdownOpen(open);
-            }
-          }}
-          modal={false}
-        >
-          <DropdownMenuTrigger asChild>
-            <button
-              className={cn(
-                'flex w-full flex-1 cursor-pointer items-center justify-between overflow-hidden rounded-xl bg-zinc-950 px-3 py-2 disabled:cursor-not-allowed disabled:opacity-50',
-              )}
-              disabled={!isMorePlansEnabled}
-            >
-              <div className="flex flex-1 flex-col gap-3 lg:flex-row lg:items-center">
-                <p className="text-primary shrink-0 text-base font-semibold whitespace-nowrap">
-                  {displayPlan.name}
-                </p>
-                {displayPlan.description && (
-                  <>
-                    <div className="hidden h-4 w-px shrink-0 border-l lg:block" />
-                    <div className="block h-px w-full shrink-0 border-t lg:hidden" />
-                    <p className="text-muted-foreground w-full flex-1 overflow-hidden text-start text-base font-normal text-ellipsis">
-                      {displayPlan.description}
-                    </p>
-                  </>
-                )}
-                <div className="hidden h-4 w-px shrink-0 border-l lg:block" />
-                <div className="block h-px w-full shrink-0 border-t lg:hidden" />
-                <p className="text-muted-foreground shrink-0 text-base font-semibold whitespace-nowrap">
-                  {displayPlan.price}
-                </p>
-              </div>
-              <ChevronDown
-                className={cn(
-                  'text-muted-foreground ml-2 size-4 shrink-0 transition-transform',
-                  isDropdownOpen && 'rotate-180',
-                )}
-              />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            className="w-[var(--radix-dropdown-menu-trigger-width)] rounded-xl border bg-zinc-900 p-0"
-            align="start"
-          >
-            {morePlans.map((plan, index) => (
-              <DropdownMenuItem
-                key={plan.name}
-                onSelect={() => handlePlanSelect(plan)}
-                className={cn(
-                  'flex cursor-pointer flex-col items-start gap-3 px-3 py-2.5 focus:bg-white/5 lg:flex-row lg:items-center',
-                  index > 0 && 'border-t border-white/5',
-                )}
-              >
-                <p className="text-primary shrink-0 text-base font-semibold whitespace-nowrap">
-                  {plan.name}
-                </p>
-                {plan.description && (
-                  <>
-                    <div className="hidden h-4 w-px shrink-0 border-l lg:block" />
-                    <p className="text-muted-foreground flex-1 overflow-hidden text-base font-normal text-ellipsis">
-                      {plan.description}
-                    </p>
-                  </>
-                )}
-                <div className="hidden h-4 w-px shrink-0 border-l lg:block" />
-                <p className="text-muted-foreground shrink-0 text-base font-semibold whitespace-nowrap">
-                  {plan.price}
-                </p>
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
+    <section className={cn('container py-24', className)}>
+      <div className="mb-10 max-w-2xl">
+        <p className="text-sm font-medium text-blue-400">Scale</p>
+        <h2 className="mt-3 text-3xl font-semibold sm:text-4xl">
+          More capacity for growing workloads
+        </h2>
+        <p className="text-muted-foreground mt-4">
+          Move into larger resource packages or define a custom configuration.
+        </p>
       </div>
 
-      {isMorePlansEnabled && (
-        <Button
-          variant="secondary"
-          className="h-11 shrink-0 rounded-full px-8"
-          {...getRybbitCtaProps({
-            id: `pricing_${toRybbitCtaId(selectedPlan.name)}_get_started`,
-            location: 'pricing_more_plans',
-            destination:
-              selectedPlan.action.type === 'auth' ? 'signup_modal' : 'checkout',
-          })}
-          onClick={handleGetStarted}
-        >
-          Get Started
-        </Button>
-      )}
-    </div>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {morePlans.map((plan) => (
+          <article
+            key={plan.planId}
+            className="flex min-h-72 flex-col rounded-lg border bg-zinc-900 p-6"
+          >
+            <h3 className="text-xl font-semibold">{plan.name}</h3>
+            <p className="text-muted-foreground mt-3 min-h-16 text-sm">
+              {plan.description}
+            </p>
+            <div className="mt-6 flex items-end gap-1">
+              <span className="text-3xl font-semibold">{plan.price}</span>
+              {plan.monthlyPrice && (
+                <span className="text-muted-foreground pb-1 text-sm">
+                  / month
+                </span>
+              )}
+            </div>
+            <div className="mt-auto flex flex-col gap-2 pt-6">
+              <Button
+                variant="secondary"
+                className="h-10 rounded-full"
+                {...getRybbitCtaProps({
+                  id: `pricing_${toRybbitCtaId(plan.name)}_get_started`,
+                  location: 'pricing_more_plans',
+                  destination:
+                    plan.action.type === 'auth' ? 'signup_modal' : 'checkout',
+                })}
+                onClick={() => handlePlanClick(plan)}
+              >
+                {plan.buttonText}
+                <ArrowUpRight className="ml-2 size-4" />
+              </Button>
+              {plan.planId === 'pro' && (
+                <Button
+                  variant="ghost"
+                  className="h-10 rounded-full"
+                  onClick={() => handleCompare(plan)}
+                >
+                  <GitCompare className="mr-2 size-4" />
+                  See Railway estimate
+                </Button>
+              )}
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
   );
 }

--- a/app/[lang]/(home)/pricing/components/MorePlans.tsx
+++ b/app/[lang]/(home)/pricing/components/MorePlans.tsx
@@ -52,6 +52,17 @@ export function MorePlans({ className }: MorePlansProps) {
       ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 
+  const formatCapacity = (plan: PricingPlan) => {
+    if (!plan.resources) return plan.description;
+
+    const traffic =
+      plan.resources.traffic >= 1000
+        ? `${plan.resources.traffic / 1000}TB traffic`
+        : `${plan.resources.traffic}GB traffic`;
+
+    return `${plan.resources.cpu} vCPU · ${plan.resources.ram}Gi RAM · ${plan.resources.disk}Gi disk · ${traffic}`;
+  };
+
   return (
     <section className={cn('container py-24', className)}>
       <div className="mb-10 max-w-2xl">
@@ -64,28 +75,51 @@ export function MorePlans({ className }: MorePlansProps) {
         </p>
       </div>
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div className="overflow-hidden border-y border-white/10">
+        <div className="text-muted-foreground hidden grid-cols-[0.65fr_1.7fr_0.55fr_auto] gap-6 border-b border-white/10 px-5 py-3 text-xs lg:grid">
+          <span>Plan</span>
+          <span>Capacity</span>
+          <span>Price</span>
+          <span className="min-w-40 text-right">Action</span>
+        </div>
         {morePlans.map((plan) => (
           <article
             key={plan.planId}
-            className="flex min-h-72 flex-col rounded-lg border bg-zinc-900 p-6"
+            className="grid gap-5 border-b border-white/10 px-1 py-7 transition-colors last:border-b-0 hover:bg-white/[0.025] sm:px-5 lg:grid-cols-[0.65fr_1.7fr_0.55fr_auto] lg:items-center lg:gap-6"
           >
-            <h3 className="text-xl font-semibold">{plan.name}</h3>
-            <p className="text-muted-foreground mt-3 min-h-16 text-sm">
-              {plan.description}
+            <div>
+              <h3 className="text-lg font-semibold">{plan.name}</h3>
+              <p className="text-muted-foreground mt-1 text-xs lg:hidden">
+                Plan
+              </p>
+            </div>
+            <p className="text-muted-foreground max-w-2xl text-sm leading-6 text-pretty">
+              {formatCapacity(plan)}
             </p>
-            <div className="mt-6 flex items-end gap-1">
-              <span className="text-3xl font-semibold">{plan.price}</span>
+            <div className="flex items-end gap-1">
+              <span className="text-xl font-semibold tabular-nums">
+                {plan.price}
+              </span>
               {plan.monthlyPrice && (
                 <span className="text-muted-foreground pb-1 text-sm">
                   / month
                 </span>
               )}
             </div>
-            <div className="mt-auto flex flex-col gap-2 pt-6">
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-3 lg:min-w-40 lg:justify-end">
+              {plan.planId === 'pro' && (
+                <button
+                  type="button"
+                  className="inline-flex items-center text-sm font-medium text-zinc-300 transition-colors hover:text-white focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:outline-none"
+                  onClick={() => handleCompare(plan)}
+                >
+                  <GitCompare className="mr-2 size-4 text-blue-400" />
+                  Estimate
+                </button>
+              )}
               <Button
                 variant="secondary"
-                className="h-10 rounded-full"
+                className="h-9 px-4 transition duration-200 active:translate-y-px motion-reduce:transition-none"
                 {...getRybbitCtaProps({
                   id: `pricing_${toRybbitCtaId(plan.name)}_get_started`,
                   location: 'pricing_more_plans',
@@ -97,16 +131,6 @@ export function MorePlans({ className }: MorePlansProps) {
                 {plan.buttonText}
                 <ArrowUpRight className="ml-2 size-4" />
               </Button>
-              {plan.planId === 'pro' && (
-                <Button
-                  variant="ghost"
-                  className="h-10 rounded-full"
-                  onClick={() => handleCompare(plan)}
-                >
-                  <GitCompare className="mr-2 size-4" />
-                  See Railway estimate
-                </Button>
-              )}
             </div>
           </article>
         ))}

--- a/app/[lang]/(home)/pricing/components/PricingCard.tsx
+++ b/app/[lang]/(home)/pricing/components/PricingCard.tsx
@@ -66,26 +66,8 @@ export function PricingCard({ plan, className }: PricingCardProps) {
       ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 
-  return (
-    <article
-      className={cn(
-        'relative grid h-full grid-rows-[auto_auto_auto_auto_1fr] overflow-hidden rounded-lg border border-white/10 bg-zinc-900/70 p-7 transition duration-200 hover:-translate-y-1 hover:border-white/20 hover:shadow-[0_24px_60px_-36px_rgba(59,130,246,0.45)] motion-reduce:transform-none motion-reduce:transition-none',
-        isPopular &&
-          'border-blue-400/40 bg-blue-500/[0.06] before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-blue-400',
-        className,
-      )}
-    >
-      <div className="mb-5 h-4">
-        {isPopular ? (
-          <p className="flex items-center gap-2 text-xs font-medium text-blue-300">
-            <span className="size-1.5 bg-blue-400" aria-hidden="true" />
-            Recommended for most projects
-          </p>
-        ) : (
-          <span className="sr-only">Standard plan option</span>
-        )}
-      </div>
-
+  const cardContent = (
+    <>
       <div className="min-h-24">
         <h3 className="text-2xl font-semibold">{name}</h3>
         <p className="text-muted-foreground mt-3 max-w-sm text-sm leading-6 text-pretty">
@@ -96,7 +78,7 @@ export function PricingCard({ plan, className }: PricingCardProps) {
       <div className="mt-7 min-h-20">
         <div className="flex items-end gap-2">
           {originalPrice && (
-            <span className="text-muted-foreground text-xl leading-none tabular-nums line-through">
+            <span className="text-muted-foreground text-4xl leading-none font-semibold tabular-nums line-through opacity-70">
               {originalPrice}
             </span>
           )}
@@ -141,6 +123,31 @@ export function PricingCard({ plan, className }: PricingCardProps) {
           ))}
         </div>
       </div>
-    </article>
+    </>
+  );
+
+  return (
+    <div
+      className={cn(
+        'relative flex h-full flex-col',
+        !isPopular && 'xl:py-7',
+        className,
+      )}
+    >
+      {isPopular ? (
+        <article className="flex h-full flex-col rounded-2xl bg-gradient-to-r from-white via-blue-300 to-blue-600 p-1 transition duration-200 hover:-translate-y-1 hover:shadow-[0_24px_60px_-30px_rgba(59,130,246,0.65)] motion-reduce:transform-none motion-reduce:transition-none">
+          <div className="flex h-10 shrink-0 items-center justify-center px-4">
+            <p className="text-sm font-bold text-zinc-950">MOST POPULAR</p>
+          </div>
+          <div className="grid h-full flex-1 grid-rows-[auto_auto_auto_1fr] rounded-xl bg-zinc-900 p-7">
+            {cardContent}
+          </div>
+        </article>
+      ) : (
+        <article className="relative grid h-full flex-1 grid-rows-[auto_auto_auto_1fr] overflow-hidden rounded-lg border border-white/10 bg-zinc-900/70 p-7 transition duration-200 hover:-translate-y-1 hover:border-white/20 hover:shadow-[0_24px_60px_-36px_rgba(59,130,246,0.45)] motion-reduce:transform-none motion-reduce:transition-none">
+          {cardContent}
+        </article>
+      )}
+    </div>
   );
 }

--- a/app/[lang]/(home)/pricing/components/PricingCard.tsx
+++ b/app/[lang]/(home)/pricing/components/PricingCard.tsx
@@ -1,10 +1,11 @@
 'use client';
 
+import { GitCompare } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
-import { FeatureItem } from './FeatureItem';
 import { useAuthRedirect } from '@/hooks/use-auth-redirect';
 import { useGTM } from '@/hooks/use-gtm';
+import { cn } from '@/lib/utils';
+import { FeatureItem } from './FeatureItem';
 import type { PricingPlan } from '../config/plans';
 import { getRybbitCtaProps, toRybbitCtaId } from '@/lib/analytics/rybbit-cta';
 
@@ -15,63 +16,93 @@ interface PricingCardProps {
 
 export function PricingCard({ plan, className }: PricingCardProps) {
   const handleAuthRedirect = useAuthRedirect();
-  const { trackButton } = useGTM();
+  const { trackButton, trackCustom } = useGTM();
   const {
+    planId,
     name,
     description,
     price,
     originalPrice,
+    monthlyPrice,
     buttonText,
     buttonVariant = 'secondary',
     features,
+    resources,
     isPopular = false,
     action,
   } = plan;
 
   const handleButtonClick = () => {
     const url = action.type === 'direct' ? action.url : '';
-    trackButton(
-      'Get Started',
-      `pricing-card-${name.toLowerCase()}`,
-      'url',
-      url,
-      {
-        plan_name: name,
-        plan_price: price,
-      },
-    );
+    trackButton(buttonText, `pricing-card-${planId}`, 'url', url, {
+      plan_id: planId,
+      plan_name: name,
+      plan_price: monthlyPrice,
+    });
+    trackCustom('pricing_plan_selected', {
+      plan_id: planId,
+      plan_price: monthlyPrice,
+      location: 'primary_plan_card',
+    });
 
     if (action.type === 'auth') {
       handleAuthRedirect(action.params);
-    } else {
-      window.open(action.url, '_blank');
+      return;
     }
+
+    window.open(action.url, '_blank', 'noopener,noreferrer');
   };
 
-  const cardContent = (
-    <>
-      <div className="flex flex-col gap-3">
-        <p className="text-foreground text-2xl font-semibold">{name}</p>
-        <p className="text-muted-foreground line-clamp-2 text-base whitespace-pre-wrap">
-          {description}
+  const handleCompare = () => {
+    trackCustom('pricing_compare_plan_selected', {
+      plan_id: planId,
+      location: 'primary_plan_card',
+    });
+    window.dispatchEvent(
+      new CustomEvent('pricing:compare-plan', { detail: { planId } }),
+    );
+    document
+      .getElementById('railway-cost')
+      ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  return (
+    <article
+      className={cn(
+        'relative flex h-full flex-col rounded-lg border bg-zinc-900 p-7',
+        isPopular && 'border-blue-400/70 ring-1 ring-blue-400/30',
+        className,
+      )}
+    >
+      {isPopular && (
+        <p className="absolute top-0 right-5 -translate-y-1/2 rounded-full bg-blue-500 px-3 py-1 text-xs font-semibold text-white">
+          MOST POPULAR
         </p>
+      )}
+
+      <div className="min-h-24">
+        <h3 className="text-2xl font-semibold">{name}</h3>
+        <p className="text-muted-foreground mt-3 text-sm">{description}</p>
       </div>
 
-      <div className="flex flex-col gap-2">
-        <div className="flex items-end gap-1">
+      <div className="mt-6">
+        <div className="flex items-end gap-2">
           {originalPrice && (
-            <p className="text-foreground text-4xl font-bold line-through opacity-50">
+            <span className="text-muted-foreground text-xl line-through">
               {originalPrice}
-            </p>
+            </span>
           )}
-          <p className="text-foreground text-4xl font-bold">{price}</p>
-          <p className="text-muted-foreground text-lg">/month</p>
+          <span className="text-4xl font-bold">{price}</span>
+          <span className="text-muted-foreground pb-1">/ month</span>
         </div>
+        <p className="text-muted-foreground mt-2 text-xs">
+          Monthly resource package
+        </p>
       </div>
 
       <Button
         variant={isPopular ? 'landing-primary' : buttonVariant}
-        className="h-11 rounded-full"
+        className="mt-6 h-11 rounded-full"
         {...getRybbitCtaProps({
           id: `pricing_${toRybbitCtaId(name)}_get_started`,
           location: 'pricing_plan_card',
@@ -82,32 +113,25 @@ export function PricingCard({ plan, className }: PricingCardProps) {
         {buttonText}
       </Button>
 
-      <div className="flex flex-col gap-3">
-        {features.map((feature, index) => (
-          <FeatureItem key={index} text={feature} />
-        ))}
-      </div>
-    </>
-  );
-
-  return (
-    <div className={cn('relative flex flex-col sm:pt-7', className)}>
-      {isPopular ? (
-        <div className="relative h-[calc(100%+1.75rem+4px)] flex-col rounded-2xl bg-gradient-to-r from-white to-blue-600 p-1 pb-[calc(1.75rem+4px)] sm:-mt-[calc(1.75rem+4px)]">
-          <div className="absolute -top-0 right-0 left-0 z-10 flex items-center justify-center rounded-t-2xl px-0 py-1.5">
-            <p className="text-primary-foreground text-sm font-bold">
-              MOST POPULAR
-            </p>
-          </div>
-          <div className="relative top-7 z-0 flex h-full flex-1 flex-col gap-6 rounded-xl bg-zinc-900 p-7">
-            {cardContent}
-          </div>
-        </div>
-      ) : (
-        <div className="flex h-full flex-col gap-6 rounded-xl border bg-zinc-900 p-7">
-          <div className="flex flex-1 flex-col gap-6">{cardContent}</div>
-        </div>
+      {resources && (
+        <Button
+          variant="ghost"
+          className="mt-2 h-10 rounded-full border border-white/10"
+          onClick={handleCompare}
+        >
+          <GitCompare className="mr-2 size-4" />
+          See Railway estimate
+        </Button>
       )}
-    </div>
+
+      <div className="mt-7 border-t border-white/10 pt-6">
+        <p className="mb-4 text-sm font-medium">Included resources</p>
+        <div className="flex flex-col gap-3">
+          {features.map((feature) => (
+            <FeatureItem key={feature} text={feature} />
+          ))}
+        </div>
+      </div>
+    </article>
   );
 }

--- a/app/[lang]/(home)/pricing/components/PricingCard.tsx
+++ b/app/[lang]/(home)/pricing/components/PricingCard.tsx
@@ -23,6 +23,9 @@ export function PricingCard({ plan, className }: PricingCardProps) {
     description,
     price,
     originalPrice,
+    priceLabel,
+    originalPriceLabel,
+    offerEligibility,
     monthlyPrice,
     buttonText,
     buttonVariant = 'secondary',
@@ -75,18 +78,34 @@ export function PricingCard({ plan, className }: PricingCardProps) {
         </p>
       </div>
 
-      <div className="mt-7 min-h-20">
-        <div className="flex items-end gap-2">
+      <div className="mt-7 min-h-24">
+        <div className="flex items-end gap-3">
           {originalPrice && (
-            <span className="text-muted-foreground text-4xl leading-none font-semibold tabular-nums line-through opacity-70">
-              {originalPrice}
-            </span>
+            <div className="shrink-0">
+              <p className="text-muted-foreground mb-2 text-[11px] font-medium uppercase">
+                {originalPriceLabel ?? 'Regular price'}
+              </p>
+              <p className="text-muted-foreground text-3xl leading-none font-semibold tabular-nums line-through opacity-70">
+                {originalPrice}
+              </p>
+            </div>
           )}
-          <span className="text-4xl font-semibold tabular-nums">{price}</span>
-          <span className="text-muted-foreground pb-1">/ month</span>
+          <div>
+            <p className="text-muted-foreground mb-2 text-[11px] font-medium uppercase">
+              {priceLabel ?? 'Monthly plan price'}
+            </p>
+            <div className="flex items-end gap-2">
+              <span className="text-4xl leading-none font-semibold tabular-nums">
+                {price}
+              </span>
+              <span className="text-muted-foreground pb-0.5">/ month</span>
+            </div>
+          </div>
         </div>
         <p className="text-muted-foreground mt-2 text-xs">
-          Monthly resource package
+          {offerEligibility
+            ? `${offerEligibility} · Eligibility confirmed in Cost Center`
+            : 'Fixed monthly resource package'}
         </p>
       </div>
 
@@ -137,7 +156,9 @@ export function PricingCard({ plan, className }: PricingCardProps) {
       {isPopular ? (
         <article className="flex h-full flex-col rounded-2xl bg-gradient-to-r from-white via-blue-300 to-blue-600 p-1 transition duration-200 hover:-translate-y-1 hover:shadow-[0_24px_60px_-30px_rgba(59,130,246,0.65)] motion-reduce:transform-none motion-reduce:transition-none">
           <div className="flex h-10 shrink-0 items-center justify-center px-4">
-            <p className="text-sm font-bold text-zinc-950">MOST POPULAR</p>
+            <p className="text-center text-sm font-bold text-zinc-950">
+              RECOMMENDED FOR MOST PROJECTS
+            </p>
           </div>
           <div className="grid h-full flex-1 grid-rows-[auto_auto_auto_1fr] rounded-xl bg-zinc-900 p-7">
             {cardContent}

--- a/app/[lang]/(home)/pricing/components/PricingCard.tsx
+++ b/app/[lang]/(home)/pricing/components/PricingCard.tsx
@@ -69,30 +69,38 @@ export function PricingCard({ plan, className }: PricingCardProps) {
   return (
     <article
       className={cn(
-        'relative flex h-full flex-col rounded-lg border bg-zinc-900 p-7',
-        isPopular && 'border-blue-400/70 ring-1 ring-blue-400/30',
+        'relative grid h-full grid-rows-[auto_auto_auto_auto_1fr] overflow-hidden rounded-lg border border-white/10 bg-zinc-900/70 p-7 transition duration-200 hover:-translate-y-1 hover:border-white/20 hover:shadow-[0_24px_60px_-36px_rgba(59,130,246,0.45)] motion-reduce:transform-none motion-reduce:transition-none',
+        isPopular &&
+          'border-blue-400/40 bg-blue-500/[0.06] before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-blue-400',
         className,
       )}
     >
-      {isPopular && (
-        <p className="absolute top-0 right-5 -translate-y-1/2 rounded-full bg-blue-500 px-3 py-1 text-xs font-semibold text-white">
-          MOST POPULAR
-        </p>
-      )}
+      <div className="mb-5 h-4">
+        {isPopular ? (
+          <p className="flex items-center gap-2 text-xs font-medium text-blue-300">
+            <span className="size-1.5 bg-blue-400" aria-hidden="true" />
+            Recommended for most projects
+          </p>
+        ) : (
+          <span className="sr-only">Standard plan option</span>
+        )}
+      </div>
 
       <div className="min-h-24">
         <h3 className="text-2xl font-semibold">{name}</h3>
-        <p className="text-muted-foreground mt-3 text-sm">{description}</p>
+        <p className="text-muted-foreground mt-3 max-w-sm text-sm leading-6 text-pretty">
+          {description}
+        </p>
       </div>
 
-      <div className="mt-6">
+      <div className="mt-7 min-h-20">
         <div className="flex items-end gap-2">
           {originalPrice && (
-            <span className="text-muted-foreground text-xl line-through">
+            <span className="text-muted-foreground text-xl leading-none tabular-nums line-through">
               {originalPrice}
             </span>
           )}
-          <span className="text-4xl font-bold">{price}</span>
+          <span className="text-4xl font-semibold tabular-nums">{price}</span>
           <span className="text-muted-foreground pb-1">/ month</span>
         </div>
         <p className="text-muted-foreground mt-2 text-xs">
@@ -100,29 +108,30 @@ export function PricingCard({ plan, className }: PricingCardProps) {
         </p>
       </div>
 
-      <Button
-        variant={isPopular ? 'landing-primary' : buttonVariant}
-        className="mt-6 h-11 rounded-full"
-        {...getRybbitCtaProps({
-          id: `pricing_${toRybbitCtaId(name)}_get_started`,
-          location: 'pricing_plan_card',
-          destination: action.type === 'auth' ? 'signup_modal' : 'checkout',
-        })}
-        onClick={handleButtonClick}
-      >
-        {buttonText}
-      </Button>
-
-      {resources && (
+      <div className="mt-6">
         <Button
-          variant="ghost"
-          className="mt-2 h-10 rounded-full border border-white/10"
-          onClick={handleCompare}
+          variant={isPopular ? 'landing-primary' : buttonVariant}
+          className="h-11 w-full rounded-md transition duration-200 active:translate-y-px motion-reduce:transition-none"
+          {...getRybbitCtaProps({
+            id: `pricing_${toRybbitCtaId(name)}_get_started`,
+            location: 'pricing_plan_card',
+            destination: action.type === 'auth' ? 'signup_modal' : 'checkout',
+          })}
+          onClick={handleButtonClick}
         >
-          <GitCompare className="mr-2 size-4" />
-          See Railway estimate
+          {buttonText}
         </Button>
-      )}
+        {resources && (
+          <button
+            type="button"
+            className="mt-4 inline-flex items-center text-sm font-medium text-zinc-300 transition-colors hover:text-white focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:outline-none motion-reduce:transition-none"
+            onClick={handleCompare}
+          >
+            <GitCompare className="mr-2 size-4 text-blue-400" />
+            Compare with Railway
+          </button>
+        )}
+      </div>
 
       <div className="mt-7 border-t border-white/10 pt-6">
         <p className="mb-4 text-sm font-medium">Included resources</p>

--- a/app/[lang]/(home)/pricing/components/RailwayCostCalculator.tsx
+++ b/app/[lang]/(home)/pricing/components/RailwayCostCalculator.tsx
@@ -1,0 +1,436 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import {
+  ArrowRight,
+  ChevronDown,
+  ExternalLink,
+  SlidersHorizontal,
+} from 'lucide-react';
+import RailwayIcon from '@/assets/platform-icons/railway.svg';
+import SealosIcon from '@/assets/shared-icons/sealos.svg';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useGTM } from '@/hooks/use-gtm';
+import { cn } from '@/lib/utils';
+import { railwayComparablePlans, type PricingPlanId } from '../config/plans';
+import {
+  RAILWAY_RATE_CARD,
+  calculateBreakEvenUtilization,
+  calculateCostDifference,
+  estimateRailwayMonthlyCost,
+  formatUsd,
+  type RailwayCostInput,
+} from '../config/railway-cost';
+
+const utilizationOptions = [10, 25, 50, 100] as const;
+type Utilization = (typeof utilizationOptions)[number];
+
+interface RailwayCostCalculatorProps {
+  lang: string;
+}
+
+const buildInputs = (
+  plan: (typeof railwayComparablePlans)[number],
+  utilization: Utilization,
+): RailwayCostInput => ({
+  averageVcpu: plan.resources.cpu * (utilization / 100),
+  averageRamGb: plan.resources.ram * (utilization / 100),
+  volumeGb: plan.resources.disk,
+  egressGb: plan.resources.traffic,
+});
+
+export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
+  const { trackCustom } = useGTM();
+  const sectionRef = useRef<HTMLElement>(null);
+  const hasTrackedView = useRef(false);
+  const defaultPlan = railwayComparablePlans.find(
+    ({ planId }) => planId === 'hobby',
+  )!;
+  const [selectedPlanId, setSelectedPlanId] = useState<PricingPlanId>('hobby');
+  const [utilization, setUtilization] = useState<Utilization>(25);
+  const [inputs, setInputs] = useState<RailwayCostInput>(() =>
+    buildInputs(defaultPlan, 25),
+  );
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  const selectedPlan =
+    railwayComparablePlans.find(({ planId }) => planId === selectedPlanId) ??
+    defaultPlan;
+
+  const selectPlan = useCallback(
+    (planId: PricingPlanId, shouldTrack: boolean) => {
+      const plan = railwayComparablePlans.find(
+        (candidate) => candidate.planId === planId,
+      );
+      if (!plan) return;
+
+      setSelectedPlanId(plan.planId);
+      setInputs(buildInputs(plan, utilization));
+      if (shouldTrack) {
+        trackCustom('pricing_compare_plan_selected', {
+          plan_id: plan.planId,
+          location: 'railway_calculator',
+        });
+      }
+    },
+    [trackCustom, utilization],
+  );
+
+  useEffect(() => {
+    const handleExternalPlanSelection = (
+      event: Event & { detail?: { planId?: PricingPlanId } },
+    ) => {
+      if (event.detail?.planId) selectPlan(event.detail.planId, false);
+    };
+
+    window.addEventListener(
+      'pricing:compare-plan',
+      handleExternalPlanSelection as EventListener,
+    );
+    return () =>
+      window.removeEventListener(
+        'pricing:compare-plan',
+        handleExternalPlanSelection as EventListener,
+      );
+  }, [selectPlan]);
+
+  useEffect(() => {
+    const section = sectionRef.current;
+    if (!section) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !hasTrackedView.current) {
+          hasTrackedView.current = true;
+          trackCustom('pricing_railway_compare_viewed', {
+            default_plan_id: 'hobby',
+            default_utilization: 25,
+          });
+        }
+      },
+      { threshold: 0.2 },
+    );
+    observer.observe(section);
+    return () => observer.disconnect();
+  }, [trackCustom]);
+
+  const estimate = useMemo(() => estimateRailwayMonthlyCost(inputs), [inputs]);
+  const difference = calculateCostDifference(
+    selectedPlan.monthlyPrice,
+    estimate.total,
+  );
+  const crossover = calculateBreakEvenUtilization({
+    sealosMonthlyPrice: selectedPlan.monthlyPrice,
+    cpu: selectedPlan.resources.cpu,
+    ram: selectedPlan.resources.ram,
+    volume: inputs.volumeGb,
+    egress: inputs.egressGb,
+  });
+
+  const handleUtilizationChange = (nextUtilization: Utilization) => {
+    setUtilization(nextUtilization);
+    setInputs(buildInputs(selectedPlan, nextUtilization));
+    trackCustom('pricing_utilization_changed', {
+      plan_id: selectedPlan.planId,
+      utilization: nextUtilization,
+    });
+  };
+
+  const updateInput = (key: keyof RailwayCostInput, value: string) => {
+    const parsed = Number(value);
+    setInputs((current) => ({
+      ...current,
+      [key]: Number.isFinite(parsed) ? Math.max(0, parsed) : 0,
+    }));
+  };
+
+  const handleAdvancedBlur = (field: keyof RailwayCostInput) => {
+    trackCustom('pricing_utilization_changed', {
+      plan_id: selectedPlan.planId,
+      utilization: 'custom',
+      field,
+      value: inputs[field],
+    });
+  };
+
+  const handleSourceClick = (source: string) => {
+    trackCustom('pricing_source_clicked', {
+      source,
+      plan_id: selectedPlan.planId,
+    });
+  };
+
+  const handleChoosePlan = () => {
+    trackCustom('pricing_plan_selected', {
+      plan_id: selectedPlan.planId,
+      plan_price: selectedPlan.monthlyPrice,
+      location: 'railway_calculator',
+    });
+    if (selectedPlan.action.type === 'direct') {
+      window.open(selectedPlan.action.url, '_blank', 'noopener,noreferrer');
+    }
+  };
+
+  const comparisonMessage =
+    difference.lowerCost === 'equal'
+      ? 'Both options have the same monthly cost in this example.'
+      : `${difference.lowerCost === 'sealos' ? 'Sealos' : 'Railway'} is about ${formatUsd(difference.amount)} lower in this example.`;
+
+  return (
+    <section
+      ref={sectionRef}
+      id="railway-cost"
+      className="scroll-mt-20 border-y border-white/10 bg-zinc-950/60 py-24"
+    >
+      <div className="container">
+        <div className="max-w-3xl">
+          <p className="text-sm font-medium text-blue-400">Cost comparison</p>
+          <h2 className="mt-3 text-3xl font-semibold sm:text-4xl">
+            Same workload. Different billing model.
+          </h2>
+          <p className="text-muted-foreground mt-4 max-w-2xl">
+            Sealos lists a monthly resource package. Railway starts with a $5
+            minimum usage commitment and bills measured CPU, memory, volume, and
+            egress.
+          </p>
+        </div>
+
+        <div className="mt-10 grid gap-8 lg:grid-cols-[1fr_auto] lg:items-end">
+          <div>
+            <p className="mb-3 text-sm font-medium">Sealos plan</p>
+            <div
+              className="grid grid-cols-2 rounded-lg border border-white/10 bg-black/20 p-1 sm:grid-cols-4"
+              role="group"
+              aria-label="Sealos plan"
+            >
+              {railwayComparablePlans.map((plan) => (
+                <button
+                  key={plan.planId}
+                  type="button"
+                  aria-pressed={selectedPlan.planId === plan.planId}
+                  onClick={() => selectPlan(plan.planId, true)}
+                  className={cn(
+                    'h-10 rounded-md px-4 text-sm font-medium transition-colors',
+                    selectedPlan.planId === plan.planId
+                      ? 'bg-white text-zinc-950'
+                      : 'text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  {plan.name}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <p className="mb-3 text-sm font-medium">Average CPU and RAM use</p>
+            <div
+              className="grid grid-cols-4 rounded-lg border border-white/10 bg-black/20 p-1"
+              role="group"
+              aria-label="Average CPU and RAM utilization"
+            >
+              {utilizationOptions.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  aria-pressed={utilization === option}
+                  onClick={() => handleUtilizationChange(option)}
+                  className={cn(
+                    'h-10 min-w-16 rounded-md px-3 text-sm font-medium transition-colors',
+                    utilization === option
+                      ? 'bg-white text-zinc-950'
+                      : 'text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  {option}%
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-8 grid gap-5 lg:grid-cols-2">
+          <article className="flex min-h-72 flex-col rounded-lg border border-blue-400/40 bg-zinc-900 p-6 sm:p-8">
+            <div className="flex items-center gap-3">
+              <div className="flex size-10 items-center justify-center rounded-md bg-white p-2">
+                <Image src={SealosIcon} alt="Sealos" width={28} height={28} />
+              </div>
+              <div>
+                <p className="font-semibold">Sealos {selectedPlan.name}</p>
+                <p className="text-muted-foreground text-sm">
+                  Known monthly plan price
+                </p>
+              </div>
+            </div>
+            <div className="mt-8 flex items-end gap-2">
+              <span className="text-5xl font-semibold">
+                {formatUsd(selectedPlan.monthlyPrice)}
+              </span>
+              <span className="text-muted-foreground pb-1">/ month</span>
+            </div>
+            <p className="text-muted-foreground mt-5 text-sm leading-6">
+              Includes {selectedPlan.resources.cpu} vCPU,{' '}
+              {selectedPlan.resources.ram}GB RAM, {selectedPlan.resources.disk}
+              GB disk, and {selectedPlan.resources.traffic}GB traffic.
+            </p>
+          </article>
+
+          <article className="flex min-h-72 flex-col rounded-lg border bg-zinc-900 p-6 sm:p-8">
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-3">
+                <div className="flex size-10 items-center justify-center rounded-md border border-white/10 bg-black p-2">
+                  <Image
+                    src={RailwayIcon}
+                    alt="Railway"
+                    width={28}
+                    height={28}
+                  />
+                </div>
+                <div>
+                  <p className="font-semibold">Railway</p>
+                  <p className="text-muted-foreground text-sm">
+                    Estimated usage bill
+                  </p>
+                </div>
+              </div>
+              <span className="rounded-full border border-white/10 px-3 py-1 text-xs">
+                $5 minimum usage
+              </span>
+            </div>
+            <div className="mt-8 flex items-end gap-2">
+              <span className="text-5xl font-semibold">
+                ~{formatUsd(estimate.total)}
+              </span>
+              <span className="text-muted-foreground pb-1">/ month</span>
+            </div>
+            <p className="text-muted-foreground mt-5 text-sm leading-6">
+              Assumes {inputs.averageVcpu.toFixed(2)} average vCPU,{' '}
+              {inputs.averageRamGb.toFixed(2)}GB average RAM, {inputs.volumeGb}
+              GB volume, and {inputs.egressGb}GB egress.
+            </p>
+          </article>
+        </div>
+
+        <div className="mt-6 grid gap-6 border-y border-white/10 py-7 md:grid-cols-2 md:items-center">
+          <div>
+            <p className="text-lg font-semibold">{comparisonMessage}</p>
+            <p className="text-muted-foreground mt-2 text-sm">
+              Absolute difference: {formatUsd(difference.amount)} (
+              {difference.percentage}% of the Railway estimate).
+            </p>
+          </div>
+          <p className="text-muted-foreground text-sm leading-6 md:text-right">
+            With the listed volume and egress, Railway reaches{' '}
+            {formatUsd(selectedPlan.monthlyPrice)} at about{' '}
+            <span className="text-foreground font-medium">
+              {crossover?.toFixed(1)}% average compute utilization
+            </span>
+            .
+          </p>
+        </div>
+
+        <div className="mt-6">
+          <Button
+            variant="ghost"
+            className="h-10 rounded-full border border-white/10"
+            onClick={() => setShowAdvanced((current) => !current)}
+            aria-expanded={showAdvanced}
+          >
+            <SlidersHorizontal className="mr-2 size-4" />
+            Adjust workload inputs
+            <ChevronDown
+              className={cn(
+                'ml-2 size-4 transition-transform',
+                showAdvanced && 'rotate-180',
+              )}
+            />
+          </Button>
+
+          {showAdvanced && (
+            <div className="mt-5 grid gap-4 rounded-lg border border-white/10 bg-black/20 p-5 sm:grid-cols-2 lg:grid-cols-4">
+              {(
+                [
+                  ['averageVcpu', 'Average vCPU', 0.01],
+                  ['averageRamGb', 'Average RAM (GB)', 0.01],
+                  ['volumeGb', 'Volume (GB)', 1],
+                  ['egressGb', 'Egress (GB)', 1],
+                ] as const
+              ).map(([key, label, step]) => (
+                <label key={key} className="text-sm font-medium">
+                  {label}
+                  <Input
+                    type="number"
+                    min={0}
+                    step={step}
+                    value={inputs[key]}
+                    onChange={(event) => updateInput(key, event.target.value)}
+                    onBlur={() => handleAdvancedBlur(key)}
+                    className="mt-2 h-11 bg-zinc-950"
+                  />
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="mt-8 grid gap-6 lg:grid-cols-[1fr_auto] lg:items-end">
+          <div className="text-muted-foreground text-sm leading-6">
+            <p className="font-mono text-xs text-zinc-300">
+              max($5, {inputs.averageVcpu.toFixed(2)} vCPU × $20 +{' '}
+              {inputs.averageRamGb.toFixed(2)}GB RAM × $10 + {inputs.volumeGb}GB
+              volume × $0.15 + {inputs.egressGb}GB egress × $0.05)
+            </p>
+            <p className="mt-3">
+              CPU {formatUsd(estimate.cpu)} · RAM {formatUsd(estimate.ram)} ·
+              Volume {formatUsd(estimate.volume)} · Egress{' '}
+              {formatUsd(estimate.egress)}. Estimate verified on{' '}
+              {RAILWAY_RATE_CARD.verifiedAt}.
+            </p>
+            <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2">
+              <a
+                href={RAILWAY_RATE_CARD.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => handleSourceClick('railway_pricing_plans')}
+                className="text-foreground inline-flex items-center underline underline-offset-4"
+              >
+                Railway pricing source
+                <ExternalLink className="ml-1.5 size-3.5" />
+              </a>
+              <a
+                href={RAILWAY_RATE_CARD.costControlUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => handleSourceClick('railway_cost_control')}
+                className="text-foreground inline-flex items-center underline underline-offset-4"
+              >
+                Railway cost controls
+                <ExternalLink className="ml-1.5 size-3.5" />
+              </a>
+              <Link
+                href={`/${lang}/comparison/sealos-vs-railway/`}
+                onClick={() => handleSourceClick('full_railway_comparison')}
+                className="text-foreground inline-flex items-center underline underline-offset-4"
+              >
+                View full Sealos vs. Railway comparison
+                <ArrowRight className="ml-1.5 size-3.5" />
+              </Link>
+            </div>
+          </div>
+
+          <Button
+            variant="landing-primary"
+            className="h-11 px-6"
+            onClick={handleChoosePlan}
+          >
+            Choose {selectedPlan.name}
+            <ArrowRight className="ml-2 size-4" />
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/[lang]/(home)/pricing/components/RailwayCostCalculator.tsx
+++ b/app/[lang]/(home)/pricing/components/RailwayCostCalculator.tsx
@@ -178,27 +178,88 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
     difference.lowerCost === 'equal'
       ? 'Both options have the same monthly cost in this example.'
       : `${difference.lowerCost === 'sealos' ? 'Sealos' : 'Railway'} is about ${formatUsd(difference.amount)} lower in this example.`;
+  const lowerCostName =
+    difference.lowerCost === 'equal'
+      ? 'Equal monthly cost'
+      : `${difference.lowerCost === 'sealos' ? 'Sealos' : 'Railway'} lower`;
+  const currentComputeUtilization = Math.max(
+    0,
+    Math.min(
+      100,
+      ((inputs.averageVcpu / selectedPlan.resources.cpu +
+        inputs.averageRamGb / selectedPlan.resources.ram) /
+        2) *
+        100,
+    ),
+  );
+  const markerTransform = (position: number) => {
+    if (position <= 8) return 'translateX(0)';
+    if (position >= 92) return 'translateX(-100%)';
+    return 'translateX(-50%)';
+  };
+  const costLineItems = [
+    {
+      label: 'CPU',
+      value: estimate.cpu,
+      rate: `${formatUsd(RAILWAY_RATE_CARD.cpuPerVcpuMonth)} / avg vCPU`,
+    },
+    {
+      label: 'RAM',
+      value: estimate.ram,
+      rate: `${formatUsd(RAILWAY_RATE_CARD.ramPerGbMonth)} / avg GB`,
+    },
+    {
+      label: 'Volume',
+      value: estimate.volume,
+      rate: `${formatUsd(RAILWAY_RATE_CARD.volumePerGbMonth)} / GB`,
+    },
+    {
+      label: 'Egress',
+      value: estimate.egress,
+      rate: `${formatUsd(RAILWAY_RATE_CARD.egressPerGb)} / GB`,
+    },
+  ];
 
   return (
     <section
       ref={sectionRef}
       id="railway-cost"
-      className="scroll-mt-20 border-y border-white/10 bg-zinc-950/60 py-24"
+      className="scroll-mt-20 border-y border-white/10 bg-zinc-950/60 py-24 sm:py-28"
     >
       <div className="container">
-        <div className="max-w-3xl">
-          <p className="text-sm font-medium text-blue-400">Cost comparison</p>
-          <h2 className="mt-3 text-3xl font-semibold sm:text-4xl">
-            Same workload. Different billing model.
-          </h2>
-          <p className="text-muted-foreground mt-4 max-w-2xl">
-            Sealos lists a monthly resource package. Railway starts with a $5
-            minimum usage commitment and bills measured CPU, memory, volume, and
-            egress.
-          </p>
+        <div className="grid gap-8 lg:grid-cols-[1fr_auto] lg:items-end">
+          <div className="max-w-3xl">
+            <p className="flex items-center gap-2 text-sm font-medium text-blue-400">
+              <span className="size-1.5 bg-blue-400" aria-hidden="true" />
+              Cost comparison
+            </p>
+            <h2 className="mt-3 text-3xl font-semibold text-balance sm:text-4xl">
+              Same workload. Different billing model.
+            </h2>
+            <p className="text-muted-foreground mt-4 max-w-2xl leading-7 text-pretty">
+              Sealos lists a monthly resource package. Railway starts with a $5
+              minimum usage commitment and bills measured CPU, memory, volume,
+              and egress.
+            </p>
+          </div>
+          <div className="flex flex-col items-start gap-1 lg:items-end lg:text-right">
+            <a
+              href={RAILWAY_RATE_CARD.sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => handleSourceClick('railway_pricing_plans')}
+              className="inline-flex items-center text-sm font-medium text-zinc-200 underline decoration-white/30 underline-offset-4 transition-colors hover:text-white focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:outline-none"
+            >
+              Official Railway rate model
+              <ExternalLink className="ml-1.5 size-3.5" />
+            </a>
+            <p className="text-muted-foreground text-xs">
+              Verified {RAILWAY_RATE_CARD.verifiedAt}
+            </p>
+          </div>
         </div>
 
-        <div className="mt-10 grid gap-8 lg:grid-cols-[1fr_auto] lg:items-end">
+        <div className="mt-10 grid gap-7 border-y border-white/10 py-6 lg:grid-cols-[1fr_auto] lg:items-end">
           <div>
             <p className="mb-3 text-sm font-medium">Sealos plan</p>
             <div
@@ -213,7 +274,7 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
                   aria-pressed={selectedPlan.planId === plan.planId}
                   onClick={() => selectPlan(plan.planId, true)}
                   className={cn(
-                    'h-10 rounded-md px-4 text-sm font-medium transition-colors',
+                    'h-10 rounded-md px-3 text-sm font-medium transition duration-200 focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:outline-none active:translate-y-px motion-reduce:transition-none',
                     selectedPlan.planId === plan.planId
                       ? 'bg-white text-zinc-950'
                       : 'text-muted-foreground hover:text-foreground',
@@ -239,7 +300,7 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
                   aria-pressed={utilization === option}
                   onClick={() => handleUtilizationChange(option)}
                   className={cn(
-                    'h-10 min-w-16 rounded-md px-3 text-sm font-medium transition-colors',
+                    'h-10 min-w-0 rounded-md px-2 text-sm font-medium transition duration-200 focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:outline-none active:translate-y-px motion-reduce:transition-none sm:min-w-16 sm:px-3',
                     utilization === option
                       ? 'bg-white text-zinc-950'
                       : 'text-muted-foreground hover:text-foreground',
@@ -252,34 +313,39 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
           </div>
         </div>
 
-        <div className="mt-8 grid gap-5 lg:grid-cols-2">
-          <article className="flex min-h-72 flex-col rounded-lg border border-blue-400/40 bg-zinc-900 p-6 sm:p-8">
-            <div className="flex items-center gap-3">
-              <div className="flex size-10 items-center justify-center rounded-md bg-white p-2">
-                <Image src={SealosIcon} alt="Sealos" width={28} height={28} />
+        <div className="mt-10 grid gap-5 lg:grid-cols-2">
+          <article className="flex min-h-72 flex-col rounded-lg border border-blue-400/40 bg-blue-500/[0.06] p-6 shadow-[0_24px_70px_-44px_rgba(59,130,246,0.8)] sm:p-8">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div className="flex items-center gap-3">
+                <div className="flex size-10 items-center justify-center rounded-md bg-white p-2">
+                  <Image src={SealosIcon} alt="Sealos" width={28} height={28} />
+                </div>
+                <div>
+                  <p className="font-semibold">Sealos {selectedPlan.name}</p>
+                  <p className="text-muted-foreground text-sm">
+                    Known monthly plan price
+                  </p>
+                </div>
               </div>
-              <div>
-                <p className="font-semibold">Sealos {selectedPlan.name}</p>
-                <p className="text-muted-foreground text-sm">
-                  Known monthly plan price
-                </p>
-              </div>
+              <span className="border border-blue-400/25 bg-blue-400/10 px-2 py-1 text-xs font-medium text-blue-200">
+                Fixed resource package
+              </span>
             </div>
-            <div className="mt-8 flex items-end gap-2">
-              <span className="text-5xl font-semibold">
+            <div className="mt-auto flex items-end gap-2 pt-10">
+              <span className="text-5xl font-semibold tabular-nums">
                 {formatUsd(selectedPlan.monthlyPrice)}
               </span>
               <span className="text-muted-foreground pb-1">/ month</span>
             </div>
-            <p className="text-muted-foreground mt-5 text-sm leading-6">
+            <p className="text-muted-foreground mt-5 border-t border-blue-300/15 pt-5 text-sm leading-6">
               Includes {selectedPlan.resources.cpu} vCPU,{' '}
               {selectedPlan.resources.ram}GB RAM, {selectedPlan.resources.disk}
               GB disk, and {selectedPlan.resources.traffic}GB traffic.
             </p>
           </article>
 
-          <article className="flex min-h-72 flex-col rounded-lg border bg-zinc-900 p-6 sm:p-8">
-            <div className="flex items-center justify-between gap-4">
+          <article className="flex min-h-72 flex-col rounded-lg border border-white/10 bg-white/[0.025] p-6 sm:p-8">
+            <div className="flex flex-wrap items-start justify-between gap-4">
               <div className="flex items-center gap-3">
                 <div className="flex size-10 items-center justify-center rounded-md border border-white/10 bg-black p-2">
                   <Image
@@ -296,17 +362,22 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
                   </p>
                 </div>
               </div>
-              <span className="rounded-full border border-white/10 px-3 py-1 text-xs">
-                $5 minimum usage
-              </span>
+              <div className="flex flex-wrap gap-2">
+                <span className="border border-white/10 bg-white/5 px-2 py-1 text-xs font-medium text-zinc-200">
+                  Usage estimate
+                </span>
+                <span className="border border-white/10 px-2 py-1 text-xs text-zinc-400">
+                  $5 minimum usage
+                </span>
+              </div>
             </div>
-            <div className="mt-8 flex items-end gap-2">
-              <span className="text-5xl font-semibold">
+            <div className="mt-auto flex items-end gap-2 pt-10">
+              <span className="text-5xl font-semibold tabular-nums">
                 ~{formatUsd(estimate.total)}
               </span>
               <span className="text-muted-foreground pb-1">/ month</span>
             </div>
-            <p className="text-muted-foreground mt-5 text-sm leading-6">
+            <p className="text-muted-foreground mt-5 border-t border-white/10 pt-5 text-sm leading-6">
               Assumes {inputs.averageVcpu.toFixed(2)} average vCPU,{' '}
               {inputs.averageRamGb.toFixed(2)}GB average RAM, {inputs.volumeGb}
               GB volume, and {inputs.egressGb}GB egress.
@@ -314,28 +385,109 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
           </article>
         </div>
 
-        <div className="mt-6 grid gap-6 border-y border-white/10 py-7 md:grid-cols-2 md:items-center">
+        <div className="mt-6 grid gap-10 border-y border-white/10 py-8 lg:grid-cols-[0.75fr_1.25fr] lg:items-center lg:gap-14">
           <div>
-            <p className="text-lg font-semibold">{comparisonMessage}</p>
-            <p className="text-muted-foreground mt-2 text-sm">
-              Absolute difference: {formatUsd(difference.amount)} (
-              {difference.percentage}% of the Railway estimate).
+            <p className="text-muted-foreground text-sm">Monthly difference</p>
+            <div className="mt-2 flex flex-wrap items-end gap-x-3 gap-y-1">
+              <p className="text-4xl font-semibold tabular-nums">
+                {formatUsd(difference.amount)}
+              </p>
+              <p className="pb-1 text-sm font-medium text-zinc-200">
+                {lowerCostName}
+              </p>
+            </div>
+            <p className="text-muted-foreground mt-3 max-w-sm text-sm leading-6">
+              {comparisonMessage} The difference is {difference.percentage}% of
+              the Railway estimate.
             </p>
           </div>
-          <p className="text-muted-foreground text-sm leading-6 md:text-right">
-            With the listed volume and egress, Railway reaches{' '}
-            {formatUsd(selectedPlan.monthlyPrice)} at about{' '}
-            <span className="text-foreground font-medium">
-              {crossover?.toFixed(1)}% average compute utilization
-            </span>
-            .
-          </p>
+          <div>
+            <div className="flex items-center justify-between gap-4">
+              <p className="text-sm font-medium">
+                Compute utilization threshold
+              </p>
+              <p className="text-muted-foreground text-xs">
+                0–100% average CPU and RAM
+              </p>
+            </div>
+            <div
+              className="relative mt-10 h-2 bg-zinc-800"
+              role="img"
+              aria-label={`Current compute utilization ${currentComputeUtilization.toFixed(1)} percent${
+                crossover === null
+                  ? ''
+                  : `, break-even ${crossover.toFixed(1)} percent`
+              }`}
+            >
+              <div
+                className="absolute inset-y-0 left-0 bg-blue-500/50"
+                style={{ width: `${currentComputeUtilization}%` }}
+              />
+              <span
+                className="absolute top-1/2 size-3 -translate-y-1/2 bg-blue-400 ring-4 ring-zinc-950"
+                style={{ left: `${currentComputeUtilization}%` }}
+                aria-hidden="true"
+              />
+              <span
+                className="absolute -top-8 text-xs font-medium whitespace-nowrap text-blue-300"
+                style={{
+                  left: `${currentComputeUtilization}%`,
+                  transform: markerTransform(currentComputeUtilization),
+                }}
+              >
+                Current {currentComputeUtilization.toFixed(1)}%
+              </span>
+              {crossover !== null && (
+                <>
+                  <span
+                    className="absolute top-1/2 h-5 w-px -translate-y-1/2 bg-white"
+                    style={{ left: `${crossover}%` }}
+                    aria-hidden="true"
+                  />
+                  <span
+                    className="absolute top-5 text-xs font-medium whitespace-nowrap text-zinc-200"
+                    style={{
+                      left: `${crossover}%`,
+                      transform: markerTransform(crossover),
+                    }}
+                  >
+                    Break-even {crossover.toFixed(1)}%
+                  </span>
+                </>
+              )}
+            </div>
+            <div className="text-muted-foreground mt-9 flex justify-between text-xs">
+              <span>Lower use</span>
+              <span>Full use</span>
+            </div>
+          </div>
         </div>
 
-        <div className="mt-6">
+        <dl className="grid grid-cols-2 border-b border-white/10 lg:grid-cols-4">
+          {costLineItems.map((item, index) => (
+            <div
+              key={item.label}
+              className={cn(
+                'py-6',
+                index % 2 === 0 ? 'pr-4' : 'border-l border-white/10 pl-4',
+                index >= 2 && 'border-t border-white/10 lg:border-t-0',
+                index > 0 && 'lg:border-l lg:border-white/10 lg:px-6',
+                index === 0 && 'lg:pr-6',
+              )}
+            >
+              <dt className="text-muted-foreground text-xs">{item.label}</dt>
+              <dd className="mt-2 text-xl font-semibold tabular-nums">
+                {formatUsd(item.value)}
+              </dd>
+              <p className="text-muted-foreground mt-1 text-xs">{item.rate}</p>
+            </div>
+          ))}
+        </dl>
+
+        <div className="border-b border-white/10 py-6">
           <Button
             variant="ghost"
-            className="h-10 rounded-full border border-white/10"
+            className="h-10 px-3 transition-colors"
             onClick={() => setShowAdvanced((current) => !current)}
             aria-expanded={showAdvanced}
           >
@@ -350,7 +502,7 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
           </Button>
 
           {showAdvanced && (
-            <div className="mt-5 grid gap-4 rounded-lg border border-white/10 bg-black/20 p-5 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="mt-5 grid gap-5 border-t border-white/10 pt-6 sm:grid-cols-2 lg:grid-cols-4">
               {(
                 [
                   ['averageVcpu', 'Average vCPU', 0.01],
@@ -368,7 +520,7 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
                     value={inputs[key]}
                     onChange={(event) => updateInput(key, event.target.value)}
                     onBlur={() => handleAdvancedBlur(key)}
-                    className="mt-2 h-11 bg-zinc-950"
+                    className="mt-2 h-11 rounded-md border-white/10 bg-zinc-950 tabular-nums focus-visible:ring-blue-400"
                   />
                 </label>
               ))}
@@ -376,9 +528,9 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
           )}
         </div>
 
-        <div className="mt-8 grid gap-6 lg:grid-cols-[1fr_auto] lg:items-end">
+        <div className="mt-8 grid gap-8 lg:grid-cols-[1fr_auto] lg:items-end">
           <div className="text-muted-foreground text-sm leading-6">
-            <p className="font-mono text-xs text-zinc-300">
+            <p className="font-mono text-xs [overflow-wrap:anywhere] break-words whitespace-normal text-zinc-300">
               max($5, {inputs.averageVcpu.toFixed(2)} vCPU × $20 +{' '}
               {inputs.averageRamGb.toFixed(2)}GB RAM × $10 + {inputs.volumeGb}GB
               volume × $0.15 + {inputs.egressGb}GB egress × $0.05)
@@ -395,7 +547,7 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={() => handleSourceClick('railway_pricing_plans')}
-                className="text-foreground inline-flex items-center underline underline-offset-4"
+                className="text-foreground inline-flex items-center underline decoration-white/30 underline-offset-4 transition-colors hover:text-white focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:outline-none"
               >
                 Railway pricing source
                 <ExternalLink className="ml-1.5 size-3.5" />
@@ -405,7 +557,7 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={() => handleSourceClick('railway_cost_control')}
-                className="text-foreground inline-flex items-center underline underline-offset-4"
+                className="text-foreground inline-flex items-center underline decoration-white/30 underline-offset-4 transition-colors hover:text-white focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:outline-none"
               >
                 Railway cost controls
                 <ExternalLink className="ml-1.5 size-3.5" />
@@ -413,7 +565,7 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
               <Link
                 href={`/${lang}/comparison/sealos-vs-railway/`}
                 onClick={() => handleSourceClick('full_railway_comparison')}
-                className="text-foreground inline-flex items-center underline underline-offset-4"
+                className="text-foreground inline-flex items-center underline decoration-white/30 underline-offset-4 transition-colors hover:text-white focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:outline-none"
               >
                 View full Sealos vs. Railway comparison
                 <ArrowRight className="ml-1.5 size-3.5" />
@@ -423,7 +575,7 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
 
           <Button
             variant="landing-primary"
-            className="h-11 px-6"
+            className="h-11 w-full rounded-md px-6 transition duration-200 active:translate-y-px motion-reduce:transition-none lg:w-auto"
             onClick={handleChoosePlan}
           >
             Choose {selectedPlan.name}

--- a/app/[lang]/(home)/pricing/components/RailwayCostCalculator.tsx
+++ b/app/[lang]/(home)/pricing/components/RailwayCostCalculator.tsx
@@ -35,7 +35,7 @@ interface RailwayCostCalculatorProps {
 
 const buildInputs = (
   plan: (typeof railwayComparablePlans)[number],
-  utilization: Utilization,
+  utilization: number,
 ): RailwayCostInput => ({
   averageVcpu: plan.resources.cpu * (utilization / 100),
   averageRamGb: plan.resources.ram * (utilization / 100),
@@ -179,11 +179,11 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
 
   const comparisonMessage =
     difference.lowerCost === 'equal'
-      ? 'Both options have the same monthly cost in this example.'
-      : `${difference.lowerCost === 'sealos' ? 'Sealos' : 'Railway'} is about ${formatUsd(difference.amount)} lower in this example.`;
+      ? 'Both options have the same estimated monthly cost.'
+      : `${difference.lowerCost === 'sealos' ? 'Sealos' : 'Railway'} is estimated to cost ${formatUsd(difference.amount)} (${difference.percentage}%) less than ${difference.lowerCost === 'sealos' ? 'Railway' : 'Sealos'} in this example.`;
   const lowerCostName =
     difference.lowerCost === 'equal'
-      ? 'Equal monthly cost'
+      ? 'Equal estimated cost'
       : `${difference.lowerCost === 'sealos' ? 'Sealos' : 'Railway'} lower`;
   const currentComputeUtilization = Math.max(
     0,
@@ -200,6 +200,30 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
     if (position >= 92) return 'translateX(-100%)';
     return 'translateX(-50%)';
   };
+  const getLowerCostAtUtilization = (percentage: number) =>
+    calculateCostDifference(
+      selectedPlan.monthlyPrice,
+      estimateRailwayMonthlyCost({
+        averageVcpu: selectedPlan.resources.cpu * (percentage / 100),
+        averageRamGb: selectedPlan.resources.ram * (percentage / 100),
+        volumeGb: inputs.volumeGb,
+        egressGb: inputs.egressGb,
+      }).total,
+    ).lowerCost;
+  const lowerCostAtZero = getLowerCostAtUtilization(0);
+  const lowerCostAtFull = getLowerCostAtUtilization(100);
+  const interiorCrossover =
+    crossover !== null && crossover > 0 && crossover < 100 ? crossover : null;
+  const lowerCostLabel = (
+    lowerCost: ReturnType<typeof calculateCostDifference>['lowerCost'],
+  ) =>
+    lowerCost === 'equal'
+      ? 'Equal cost'
+      : `${lowerCost === 'sealos' ? 'Sealos' : 'Railway'} lower`;
+  const fullRangeLabel =
+    lowerCostAtZero === lowerCostAtFull
+      ? `${lowerCostLabel(lowerCostAtFull)} across 0–100%`
+      : `${lowerCostLabel(lowerCostAtZero)} at low use · ${lowerCostLabel(lowerCostAtFull)} at full use`;
   const costLineItems = [
     {
       label: 'CPU',
@@ -237,12 +261,13 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
               Cost comparison
             </p>
             <h2 className="mt-3 text-3xl font-semibold text-balance sm:text-4xl">
-              Same workload. Different billing model.
+              Same workload inputs. Different billing models.
             </h2>
             <p className="text-muted-foreground mt-4 max-w-2xl leading-7 text-pretty">
-              Sealos lists a monthly resource package. Railway starts with a $5
-              minimum usage commitment and bills measured CPU, memory, volume,
-              and egress.
+              Sealos provides the listed resources for a known monthly plan
+              price. Railway bills measured CPU, memory, volume, and egress.
+              This estimate uses Railway Hobby’s $5 monthly subscription, which
+              includes $5 of resource usage.
             </p>
           </div>
           <div className="flex flex-col items-start gap-1 lg:items-end lg:text-right">
@@ -253,7 +278,7 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
               onClick={() => handleSourceClick('railway_pricing_plans')}
               className="inline-flex items-center text-sm font-medium text-zinc-200 underline decoration-white/30 underline-offset-4 transition-colors hover:text-white focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:outline-none"
             >
-              Official Railway rate model
+              Official Railway pricing and usage rates
               <ExternalLink className="ml-1.5 size-3.5" />
             </a>
             <p className="text-muted-foreground text-xs">
@@ -290,7 +315,9 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
           </div>
 
           <div>
-            <p className="mb-3 text-sm font-medium">Average CPU and RAM use</p>
+            <p className="mb-3 text-sm font-medium">
+              Average CPU and RAM utilization
+            </p>
             <div
               className="grid grid-cols-4 rounded-lg border border-white/10 bg-black/20 p-1"
               role="group"
@@ -326,7 +353,7 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
                 <div>
                   <p className="font-semibold">Sealos {selectedPlan.name}</p>
                   <p className="text-muted-foreground text-sm">
-                    Known monthly plan price
+                    Known plan price
                   </p>
                 </div>
               </div>
@@ -342,8 +369,8 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
             </div>
             <p className="text-muted-foreground mt-5 border-t border-blue-300/15 pt-5 text-sm leading-6">
               Includes {selectedPlan.resources.cpu} vCPU,{' '}
-              {selectedPlan.resources.ram}GB RAM, {selectedPlan.resources.disk}
-              GB disk, and {selectedPlan.resources.traffic}GB traffic.
+              {selectedPlan.resources.ram}Gi RAM, {selectedPlan.resources.disk}
+              Gi disk, and {selectedPlan.resources.traffic}GB traffic.
             </p>
           </article>
 
@@ -370,7 +397,7 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
                   Usage estimate
                 </span>
                 <span className="border border-white/10 px-2 py-1 text-xs text-zinc-400">
-                  $5 minimum usage
+                  $5/mo incl. $5 usage
                 </span>
               </div>
             </div>
@@ -400,8 +427,7 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
               </p>
             </div>
             <p className="text-muted-foreground mt-3 max-w-sm text-sm leading-6">
-              {comparisonMessage} The difference is {difference.percentage}% of
-              the Railway estimate.
+              {comparisonMessage}
             </p>
           </div>
           <div>
@@ -417,9 +443,9 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
               className="relative mt-10 h-2 bg-zinc-800"
               role="img"
               aria-label={`Current compute utilization ${currentComputeUtilization.toFixed(1)} percent${
-                crossover === null
+                interiorCrossover === null
                   ? ''
-                  : `, break-even ${crossover.toFixed(1)} percent`
+                  : `, break-even ${interiorCrossover.toFixed(1)} percent`
               }`}
             >
               <div
@@ -440,28 +466,40 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
               >
                 Current {currentComputeUtilization.toFixed(1)}%
               </span>
-              {crossover !== null && (
+              {interiorCrossover !== null && (
                 <>
                   <span
                     className="absolute top-1/2 h-5 w-px -translate-y-1/2 bg-white"
-                    style={{ left: `${crossover}%` }}
+                    style={{ left: `${interiorCrossover}%` }}
                     aria-hidden="true"
                   />
                   <span
                     className="absolute top-5 text-xs font-medium whitespace-nowrap text-zinc-200"
                     style={{
-                      left: `${crossover}%`,
-                      transform: markerTransform(crossover),
+                      left: `${interiorCrossover}%`,
+                      transform: markerTransform(interiorCrossover),
                     }}
                   >
-                    Break-even {crossover.toFixed(1)}%
+                    Break-even {interiorCrossover.toFixed(1)}%
                   </span>
                 </>
               )}
             </div>
-            <div className="text-muted-foreground mt-9 flex justify-between text-xs">
-              <span>Lower use</span>
-              <span>Full use</span>
+            <div className="text-muted-foreground mt-9 flex justify-between gap-4 text-xs">
+              {interiorCrossover !== null ? (
+                <>
+                  <span>
+                    {lowerCostLabel(lowerCostAtZero)} below{' '}
+                    {interiorCrossover.toFixed(1)}%
+                  </span>
+                  <span className="text-right">
+                    {lowerCostLabel(lowerCostAtFull)} above{' '}
+                    {interiorCrossover.toFixed(1)}%
+                  </span>
+                </>
+              ) : (
+                <span>{fullRangeLabel}</span>
+              )}
             </div>
           </div>
         </div>
@@ -534,15 +572,33 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
         <div className="mt-8 grid gap-8 lg:grid-cols-[1fr_auto] lg:items-end">
           <div className="text-muted-foreground text-sm leading-6">
             <p className="font-mono text-xs [overflow-wrap:anywhere] break-words whitespace-normal text-zinc-300">
-              max($5, {inputs.averageVcpu.toFixed(2)} vCPU × $20 +{' '}
-              {inputs.averageRamGb.toFixed(2)}GB RAM × $10 + {inputs.volumeGb}GB
-              volume × $0.15 + {inputs.egressGb}GB egress × $0.05)
+              max(
+              {formatUsd(RAILWAY_RATE_CARD.hobbyMonthlySubscription)}{' '}
+              subscription, {inputs.averageVcpu.toFixed(2)} vCPU ×{' '}
+              {formatUsd(RAILWAY_RATE_CARD.cpuPerVcpuMonth)} +{' '}
+              {inputs.averageRamGb.toFixed(2)}GB RAM ×{' '}
+              {formatUsd(RAILWAY_RATE_CARD.ramPerGbMonth)} + {inputs.volumeGb}GB
+              volume × {formatUsd(RAILWAY_RATE_CARD.volumePerGbMonth)} +{' '}
+              {inputs.egressGb}GB egress ×{' '}
+              {formatUsd(RAILWAY_RATE_CARD.egressPerGb)})
             </p>
             <p className="mt-3">
               CPU {formatUsd(estimate.cpu)} · RAM {formatUsd(estimate.ram)} ·
               Volume {formatUsd(estimate.volume)} · Egress{' '}
               {formatUsd(estimate.egress)}. Estimate verified on{' '}
               {RAILWAY_RATE_CARD.verifiedAt}.
+            </p>
+            <p className="mt-3">
+              This calculator applies Railway Hobby’s{' '}
+              {formatUsd(RAILWAY_RATE_CARD.hobbyMonthlySubscription)}/month
+              subscription and {formatUsd(RAILWAY_RATE_CARD.hobbyIncludedUsage)}{' '}
+              of included usage. Some workloads may require another Railway plan
+              because plan limits vary.
+            </p>
+            <p className="mt-2">
+              Sealos plan capacities use Gi. Railway publishes RAM and volume
+              rates in GB. This estimate uses the displayed numeric workload
+              inputs.
             </p>
             <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2">
               <a
@@ -552,7 +608,7 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
                 onClick={() => handleSourceClick('railway_pricing_plans')}
                 className="text-foreground inline-flex items-center underline decoration-white/30 underline-offset-4 transition-colors hover:text-white focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:outline-none"
               >
-                Railway pricing source
+                Railway pricing and usage rates
                 <ExternalLink className="ml-1.5 size-3.5" />
               </a>
               <a

--- a/app/[lang]/(home)/pricing/components/RailwayCostCalculator.tsx
+++ b/app/[lang]/(home)/pricing/components/RailwayCostCalculator.tsx
@@ -17,6 +17,7 @@ import { useGTM } from '@/hooks/use-gtm';
 import { cn } from '@/lib/utils';
 import { railwayComparablePlans, type PricingPlanId } from '../config/plans';
 import {
+  DEFAULT_RAILWAY_UTILIZATION,
   RAILWAY_RATE_CARD,
   calculateBreakEvenUtilization,
   calculateCostDifference,
@@ -50,9 +51,11 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
     ({ planId }) => planId === 'hobby',
   )!;
   const [selectedPlanId, setSelectedPlanId] = useState<PricingPlanId>('hobby');
-  const [utilization, setUtilization] = useState<Utilization>(25);
+  const [utilization, setUtilization] = useState<Utilization>(
+    DEFAULT_RAILWAY_UTILIZATION,
+  );
   const [inputs, setInputs] = useState<RailwayCostInput>(() =>
-    buildInputs(defaultPlan, 25),
+    buildInputs(defaultPlan, DEFAULT_RAILWAY_UTILIZATION),
   );
   const [showAdvanced, setShowAdvanced] = useState(false);
 
@@ -107,7 +110,7 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
           hasTrackedView.current = true;
           trackCustom('pricing_railway_compare_viewed', {
             default_plan_id: 'hobby',
-            default_utilization: 25,
+            default_utilization: DEFAULT_RAILWAY_UTILIZATION,
           });
         }
       },

--- a/app/[lang]/(home)/pricing/config/faqs.ts
+++ b/app/[lang]/(home)/pricing/config/faqs.ts
@@ -5,34 +5,38 @@ export interface FAQItem {
 
 export const faqItems: FAQItem[] = [
   {
-    question: 'Is there a free Trial of Sealos?',
+    question: 'Can my monthly charge exceed the listed plan price?',
     answer:
-      "Yes! Sealos offers a free Trial that includes 4GB RAM, 4 vCPU and limited AI usage. It's perfect for getting started and exploring the platform.",
+      'The listed amount is the monthly subscription price for the included resource package. Taxes and separately purchased services can appear as additional line items. Review the Cost Center total before confirming a purchase or upgrade.',
   },
   {
-    question: 'Do I need a credit card to get started?',
+    question: 'What resources are included in each plan?',
     answer:
-      'No, you can start using Sealos without adding a payment method on the Free Trial. With the Free Trial, you can deploy small apps for free.',
+      'Each plan card lists its included CPU, RAM, disk, traffic, NodePort, and AI credits. Choose a larger plan when your workload needs more capacity.',
   },
   {
-    question: 'Can I change or cancel my plan at any time?',
+    question: 'What does Railway’s $5 price mean in the calculator?',
     answer:
-      'Absolutely. You can upgrade, downgrade, or cancel your subscription at any time from your dashboard settings. If you cancel, your subscription will remain active until the end of your current billing cycle.',
+      'Railway Hobby includes a $5 minimum monthly usage commitment. That amount counts toward measured CPU, memory, volume, and egress usage. The final estimate increases when measured usage exceeds $5.',
+  },
+  {
+    question: 'What is included in the Sealos free trial?',
+    answer:
+      'New users can start with a 7-day trial that includes 4 vCPU, 4GB RAM, 5GB volume storage, 500MB bandwidth, and 100 AI credits. No credit card is required.',
+  },
+  {
+    question: 'Can I change or cancel my plan?',
+    answer:
+      'You can manage upgrades, downgrades, and cancellation from the Cost Center. Upgrades provide the new resource package immediately. Downgrades and cancellation follow the billing-cycle date shown during confirmation.',
   },
   {
     question: 'What payment methods do you accept?',
     answer:
-      'We accept all major credit cards (Visa, Mastercard, American Express) through our secure payment processor, Stripe.',
-  },
-  {
-    question: 'Can I upgrade or downgrade at any time?',
-    answer:
-      'You can upgrade any time, and when you do, you will get to the features of your new plan, as well as access to more powerful resources, immediately. When you downgrade, the changes will take effect at the beginning of your next billing cycle.',
+      'Sealos accepts major credit cards, including Visa, Mastercard, and American Express, through Stripe.',
   },
   {
     question: 'Can I deploy with my own domain?',
     answer:
-      'Yes! You can use your own domain and we automatically provide SSL.',
+      'Yes. You can connect your own domain and Sealos provisions SSL for it.',
   },
 ];
-

--- a/app/[lang]/(home)/pricing/config/faqs.ts
+++ b/app/[lang]/(home)/pricing/config/faqs.ts
@@ -7,7 +7,12 @@ export const faqItems: FAQItem[] = [
   {
     question: 'Can my monthly charge exceed the listed plan price?',
     answer:
-      'The listed amount is the monthly subscription price for the included resource package. Taxes and separately purchased services can appear as additional line items. Review the Cost Center total before confirming a purchase or upgrade.',
+      'Your plan price covers the resources listed on the plan card. Existing workloads continue within those limits, and allocating more resources requires a manual plan upgrade. Taxes and optional services are shown separately in Cost Center before confirmation.',
+  },
+  {
+    question: 'Who qualifies for new-user pricing?',
+    answer:
+      'The $7 Starter and $25 Hobby prices apply to accounts making their first paid plan purchase. Cost Center confirms eligibility and the final price before purchase.',
   },
   {
     question: 'What resources are included in each plan?',
@@ -17,12 +22,12 @@ export const faqItems: FAQItem[] = [
   {
     question: 'What does Railway’s $5 price mean in the calculator?',
     answer:
-      'Railway Hobby includes a $5 minimum monthly usage commitment. That amount counts toward measured CPU, memory, volume, and egress usage. The final estimate increases when measured usage exceeds $5.',
+      'Railway Hobby costs $5 per month and includes $5 of resource usage. When measured CPU, memory, volume, and egress total $5 or less, the monthly bill remains $5. When measured usage exceeds $5, the monthly total follows measured usage.',
   },
   {
     question: 'What is included in the Sealos free trial?',
     answer:
-      'New users can start with a 7-day trial that includes 4 vCPU, 4GB RAM, 5GB volume storage, 500MB bandwidth, and 100 AI credits. No credit card is required.',
+      'New users receive 7 days with 4 vCPU, 4GB RAM, 5GB storage, 500MB bandwidth, and 100 AI credits. No credit card is required.',
   },
   {
     question: 'Can I change or cancel my plan?',
@@ -32,7 +37,7 @@ export const faqItems: FAQItem[] = [
   {
     question: 'What payment methods do you accept?',
     answer:
-      'Sealos accepts major credit cards, including Visa, Mastercard, and American Express, through Stripe.',
+      'Major credit cards are processed by Stripe. Available payment methods are shown in Cost Center at checkout.',
   },
   {
     question: 'Can I deploy with my own domain?',

--- a/app/[lang]/(home)/pricing/config/plans.ts
+++ b/app/[lang]/(home)/pricing/config/plans.ts
@@ -2,137 +2,200 @@ export type PlanAction =
   | { type: 'auth'; params: Record<string, string> }
   | { type: 'direct'; url: string };
 
+export type PricingPlanId =
+  | 'starter'
+  | 'hobby'
+  | 'standard'
+  | 'pro'
+  | 'team'
+  | 'enterprise'
+  | 'customized';
+
+export interface PlanResources {
+  cpu: number;
+  ram: number;
+  disk: number;
+  traffic: number;
+  nodeports: number;
+  aiCredits: number;
+}
+
 export interface PricingPlan {
+  planId: PricingPlanId;
   name: string;
   description: string;
   price: string;
+  monthlyPrice?: number;
   originalPrice?: string;
   buttonText: string;
   buttonVariant?: 'default' | 'outline' | 'secondary' | 'ghost';
   features: string[];
+  resources?: PlanResources;
   isPopular?: boolean;
   action: PlanAction;
 }
 
-export const mainPricingPlans: PricingPlan[] = [
+const buildResourceFeatures = (resources: PlanResources): string[] => [
+  `${resources.cpu} vCPU`,
+  `${resources.ram}Gi RAM`,
+  `${resources.disk}Gi Disk`,
+  `${resources.traffic >= 1000 ? `${resources.traffic / 1000}TB` : `${resources.traffic}GB`} Traffic`,
+  `${resources.nodeports} NodePort${resources.nodeports === 1 ? '' : 's'}`,
+  `${resources.aiCredits} AI Credits`,
+];
+
+const starterResources: PlanResources = {
+  cpu: 2,
+  ram: 2,
+  disk: 10,
+  traffic: 10,
+  nodeports: 4,
+  aiCredits: 100,
+};
+
+const hobbyResources: PlanResources = {
+  cpu: 4,
+  ram: 4,
+  disk: 20,
+  traffic: 50,
+  nodeports: 8,
+  aiCredits: 300,
+};
+
+const standardResources: PlanResources = {
+  cpu: 8,
+  ram: 16,
+  disk: 50,
+  traffic: 300,
+  nodeports: 16,
+  aiCredits: 800,
+};
+
+const proResources: PlanResources = {
+  cpu: 16,
+  ram: 32,
+  disk: 200,
+  traffic: 1000,
+  nodeports: 32,
+  aiCredits: 1000,
+};
+
+const allPricingPlans: PricingPlan[] = [
   {
+    planId: 'starter',
     name: 'Starter',
-    description:
-      'For beginners deploying existing images. Not for development work.',
+    description: 'For lightweight apps and existing container images.',
     price: '$7',
-    originalPrice: '$34',
-    buttonText: 'Get Started',
+    monthlyPrice: 7,
+    buttonText: 'Choose Starter',
     action: {
       type: 'direct',
       url: 'https://os.sealos.io/?openapp=system-costcenter?mode%3Dcreate%26plan%3Dstarter',
     },
-    features: [
-      '2 vCPU ',
-      '2Gi RAM',
-      '10Gi Disk',
-      '10GB Traffic',
-      '4 Nodeport',
-      '100 AI Credit',
-    ],
+    resources: starterResources,
+    features: buildResourceFeatures(starterResources),
   },
   {
+    planId: 'hobby',
     name: 'Hobby',
-    description:
-      'For hobbyists building side projects. Not for production use.',
+    description: 'For side projects, demos, and personal services.',
     price: '$25',
-    originalPrice: '$70',
-    buttonText: 'Get Started',
+    monthlyPrice: 25,
+    buttonText: 'Choose Hobby',
     action: {
       type: 'direct',
       url: 'https://os.sealos.io/?openapp=system-costcenter?mode%3Dcreate%26plan%3Dhobby',
     },
+    resources: hobbyResources,
     features: [
-      '4 vCPU ',
-      '4Gi RAM',
-      '20Gi Disk',
-      '50GB Traffic',
-      '8 Nodeport',
-      '300 AI Credits',
-      'All Starter Features',
+      ...buildResourceFeatures(hobbyResources),
+      'All Starter features',
     ],
     isPopular: true,
   },
   {
+    planId: 'standard',
     name: 'Standard',
-    description:
-      'For growing startups and apps. The ideal balance of performance and scale.',
+    description: 'For production apps and growing startups.',
     price: '$128',
-    buttonText: 'Get Started',
+    monthlyPrice: 128,
+    buttonText: 'Choose Standard',
     action: {
       type: 'direct',
-      url: 'https://os.sealos.io/?openapp=system-costcenter?mode%3dcreate',
+      url: 'https://os.sealos.io/?openapp=system-costcenter?mode%3Dcreate%26plan%3Dstandard',
     },
+    resources: standardResources,
     features: [
-      '8 vCPU',
-      '16Gi RAM',
-      '50Gi Disk',
-      '300GB Traffic',
-      '16 Nodeport',
-      '800 AI Credits',
-      'Priority Support',
-      'All Hobby Features',
+      ...buildResourceFeatures(standardResources),
+      'Priority support',
       '99.99% SLA',
     ],
   },
   {
+    planId: 'pro',
     name: 'Pro',
-    description:
-      'For professional and team workloads. Expanded capacity for scaling projects.',
+    description: 'For multi-service production workloads and teams.',
     price: '$512',
-    buttonText: 'Get Started',
+    monthlyPrice: 512,
+    buttonText: 'Choose Pro',
     action: {
       type: 'direct',
       url: 'https://os.sealos.io/?openapp=system-costcenter?mode%3Dcreate%26plan%3Dpro',
     },
+    resources: proResources,
     features: [
-      '16 vCPU ',
-      '32Gi RAM',
-      '200Gi Disk',
-      '1TB Traffic',
-      '32 Nodeport',
-      '1000 AI Credits',
-      '24/7 Dedicated Support',
-      'All Standard Features',
-      'Custom Contracts',
+      ...buildResourceFeatures(proResources),
+      '24/7 dedicated support',
     ],
   },
-];
-
-export const morePlans: PricingPlan[] = [
   {
+    planId: 'team',
     name: 'Team',
-    description:
-      '64 vCPU + 128Gi RAM + 500Gi Disk + 3TB Traffic + 64 Nodeport + 1500 AI Credits',
-    price: '$2030/month',
-    buttonText: 'Get Started',
+    description: '64 vCPU, 128Gi RAM, 500Gi Disk, and 3TB Traffic.',
+    price: '$2,030',
+    monthlyPrice: 2030,
+    buttonText: 'Choose Team',
     action: {
       type: 'direct',
       url: 'https://os.sealos.io/?openapp=system-costcenter?mode%3Dcreate%26plan%3Dteam',
     },
-    features: [],
-  },
-  {
-    name: 'Enterprise',
-    description:
-      '256 vCPU + 1024Gi RAM + 1024Gi Disk + 10TB Traffic + 128 Nodeport + 2000 AI Credits',
-    price: '$12451/month',
-    buttonText: 'Get Started',
-    action: {
-      type: 'direct',
-      url: 'https://os.sealos.io/?openapp=system-costcenter?mode%3dcreate',
+    resources: {
+      cpu: 64,
+      ram: 128,
+      disk: 500,
+      traffic: 3000,
+      nodeports: 64,
+      aiCredits: 1500,
     },
     features: [],
   },
   {
+    planId: 'enterprise',
+    name: 'Enterprise',
+    description: '256 vCPU, 1024Gi RAM, 1024Gi Disk, and 10TB Traffic.',
+    price: '$12,451',
+    monthlyPrice: 12451,
+    buttonText: 'Choose Enterprise',
+    action: {
+      type: 'direct',
+      url: 'https://os.sealos.io/?openapp=system-costcenter?mode%3Dcreate%26plan%3Denterprise',
+    },
+    resources: {
+      cpu: 256,
+      ram: 1024,
+      disk: 1024,
+      traffic: 10000,
+      nodeports: 128,
+      aiCredits: 2000,
+    },
+    features: [],
+  },
+  {
+    planId: 'customized',
     name: 'Customized',
-    description: '',
-    price: 'Contact Us',
-    buttonText: 'Get Started',
+    description: 'A resource package and support plan built around your needs.',
+    price: 'Contact us',
+    buttonText: 'Contact sales',
     action: {
       type: 'direct',
       url: 'https://forms.sealos.in/form/po5b21Si',
@@ -140,3 +203,26 @@ export const morePlans: PricingPlan[] = [
     features: [],
   },
 ];
+
+export const mainPricingPlans = allPricingPlans.filter(({ planId }) =>
+  ['starter', 'hobby', 'standard'].includes(planId),
+);
+
+export const morePlans = allPricingPlans.filter(({ planId }) =>
+  ['pro', 'team', 'enterprise', 'customized'].includes(planId),
+);
+
+export const railwayComparablePlans = allPricingPlans.filter(
+  (
+    plan,
+  ): plan is PricingPlan & {
+    monthlyPrice: number;
+    resources: PlanResources;
+  } =>
+    ['starter', 'hobby', 'standard', 'pro'].includes(plan.planId) &&
+    plan.monthlyPrice !== undefined &&
+    plan.resources !== undefined,
+);
+
+export const getPricingPlan = (planId: PricingPlanId) =>
+  allPricingPlans.find((plan) => plan.planId === planId);

--- a/app/[lang]/(home)/pricing/config/plans.ts
+++ b/app/[lang]/(home)/pricing/config/plans.ts
@@ -86,6 +86,7 @@ const allPricingPlans: PricingPlan[] = [
     name: 'Starter',
     description: 'For lightweight apps and existing container images.',
     price: '$7',
+    originalPrice: '$34',
     monthlyPrice: 7,
     buttonText: 'Choose Starter',
     action: {
@@ -100,6 +101,7 @@ const allPricingPlans: PricingPlan[] = [
     name: 'Hobby',
     description: 'For side projects, demos, and personal services.',
     price: '$25',
+    originalPrice: '$70',
     monthlyPrice: 25,
     buttonText: 'Choose Hobby',
     action: {

--- a/app/[lang]/(home)/pricing/config/plans.ts
+++ b/app/[lang]/(home)/pricing/config/plans.ts
@@ -27,6 +27,9 @@ export interface PricingPlan {
   price: string;
   monthlyPrice?: number;
   originalPrice?: string;
+  priceLabel?: string;
+  originalPriceLabel?: string;
+  offerEligibility?: string;
   buttonText: string;
   buttonVariant?: 'default' | 'outline' | 'secondary' | 'ghost';
   features: string[];
@@ -84,9 +87,13 @@ const allPricingPlans: PricingPlan[] = [
   {
     planId: 'starter',
     name: 'Starter',
-    description: 'For lightweight apps and existing container images.',
+    description:
+      'For lightweight experiments and existing container workloads.',
     price: '$7',
     originalPrice: '$34',
+    priceLabel: 'New user price',
+    originalPriceLabel: 'Regular price',
+    offerEligibility: 'First paid plan purchase',
     monthlyPrice: 7,
     buttonText: 'Choose Starter',
     action: {
@@ -99,9 +106,13 @@ const allPricingPlans: PricingPlan[] = [
   {
     planId: 'hobby',
     name: 'Hobby',
-    description: 'For side projects, demos, and personal services.',
+    description:
+      'For side projects and always-on personal apps that need more capacity.',
     price: '$25',
     originalPrice: '$70',
+    priceLabel: 'New user price',
+    originalPriceLabel: 'Regular price',
+    offerEligibility: 'First paid plan purchase',
     monthlyPrice: 25,
     buttonText: 'Choose Hobby',
     action: {
@@ -109,16 +120,14 @@ const allPricingPlans: PricingPlan[] = [
       url: 'https://os.sealos.io/?openapp=system-costcenter?mode%3Dcreate%26plan%3Dhobby',
     },
     resources: hobbyResources,
-    features: [
-      ...buildResourceFeatures(hobbyResources),
-      'All Starter features',
-    ],
+    features: buildResourceFeatures(hobbyResources),
     isPopular: true,
   },
   {
     planId: 'standard',
     name: 'Standard',
-    description: 'For production apps and growing startups.',
+    description:
+      'For production workloads that need more memory, traffic, and priority support.',
     price: '$128',
     monthlyPrice: 128,
     buttonText: 'Choose Standard',
@@ -194,7 +203,7 @@ const allPricingPlans: PricingPlan[] = [
   },
   {
     planId: 'customized',
-    name: 'Customized',
+    name: 'Custom',
     description: 'A resource package and support plan built around your needs.',
     price: 'Contact us',
     buttonText: 'Contact sales',

--- a/app/[lang]/(home)/pricing/config/railway-cost.ts
+++ b/app/[lang]/(home)/pricing/config/railway-cost.ts
@@ -1,5 +1,6 @@
 export const RAILWAY_RATE_CARD = {
-  minimumMonthlySpend: 5,
+  hobbyMonthlySubscription: 5,
+  hobbyIncludedUsage: 5,
   cpuPerVcpuMonth: 20,
   ramPerGbMonth: 10,
   volumePerGbMonth: 0.15,
@@ -7,7 +8,7 @@ export const RAILWAY_RATE_CARD = {
   sourceUrl: 'https://docs.railway.com/pricing/plans',
   faqUrl: 'https://docs.railway.com/pricing/faqs',
   costControlUrl: 'https://docs.railway.com/pricing/cost-control',
-  verifiedAt: '2026-07-24',
+  verifiedAt: '2026-07-28',
 } as const;
 
 export const DEFAULT_RAILWAY_UTILIZATION = 50;
@@ -43,7 +44,10 @@ export const estimateRailwayMonthlyCost = (
     clampToZero(input.volumeGb) * RAILWAY_RATE_CARD.volumePerGbMonth;
   const egress = clampToZero(input.egressGb) * RAILWAY_RATE_CARD.egressPerGb;
   const usageSubtotal = cpu + ram + volume + egress;
-  const total = Math.max(RAILWAY_RATE_CARD.minimumMonthlySpend, usageSubtotal);
+  const total = Math.max(
+    RAILWAY_RATE_CARD.hobbyMonthlySubscription,
+    usageSubtotal,
+  );
 
   return {
     cpu: roundCurrency(cpu),
@@ -52,7 +56,7 @@ export const estimateRailwayMonthlyCost = (
     egress: roundCurrency(egress),
     usageSubtotal: roundCurrency(usageSubtotal),
     total: roundCurrency(total),
-    minimumApplied: usageSubtotal < RAILWAY_RATE_CARD.minimumMonthlySpend,
+    minimumApplied: usageSubtotal < RAILWAY_RATE_CARD.hobbyMonthlySubscription,
   };
 };
 
@@ -94,10 +98,9 @@ export const calculateCostDifference = (
   const amount = roundCurrency(
     Math.abs(railwayMonthlyEstimate - sealosMonthlyPrice),
   );
+  const higherCost = Math.max(sealosMonthlyPrice, railwayMonthlyEstimate);
   const percentage =
-    railwayMonthlyEstimate === 0
-      ? 0
-      : Math.round((amount / railwayMonthlyEstimate) * 100);
+    higherCost === 0 ? 0 : Math.round((amount / higherCost) * 100);
 
   return {
     amount,

--- a/app/[lang]/(home)/pricing/config/railway-cost.ts
+++ b/app/[lang]/(home)/pricing/config/railway-cost.ts
@@ -1,0 +1,118 @@
+export const RAILWAY_RATE_CARD = {
+  minimumMonthlySpend: 5,
+  cpuPerVcpuMonth: 20,
+  ramPerGbMonth: 10,
+  volumePerGbMonth: 0.15,
+  egressPerGb: 0.05,
+  sourceUrl: 'https://docs.railway.com/pricing/plans',
+  faqUrl: 'https://docs.railway.com/pricing/faqs',
+  costControlUrl: 'https://docs.railway.com/pricing/cost-control',
+  verifiedAt: '2026-07-24',
+} as const;
+
+export interface RailwayCostInput {
+  averageVcpu: number;
+  averageRamGb: number;
+  volumeGb: number;
+  egressGb: number;
+}
+
+export interface RailwayCostEstimate {
+  cpu: number;
+  ram: number;
+  volume: number;
+  egress: number;
+  usageSubtotal: number;
+  total: number;
+  minimumApplied: boolean;
+}
+
+const clampToZero = (value: number) => Math.max(0, value);
+
+const roundCurrency = (value: number) => Math.round(value * 100) / 100;
+
+export const estimateRailwayMonthlyCost = (
+  input: RailwayCostInput,
+): RailwayCostEstimate => {
+  const cpu =
+    clampToZero(input.averageVcpu) * RAILWAY_RATE_CARD.cpuPerVcpuMonth;
+  const ram = clampToZero(input.averageRamGb) * RAILWAY_RATE_CARD.ramPerGbMonth;
+  const volume =
+    clampToZero(input.volumeGb) * RAILWAY_RATE_CARD.volumePerGbMonth;
+  const egress = clampToZero(input.egressGb) * RAILWAY_RATE_CARD.egressPerGb;
+  const usageSubtotal = cpu + ram + volume + egress;
+  const total = Math.max(RAILWAY_RATE_CARD.minimumMonthlySpend, usageSubtotal);
+
+  return {
+    cpu: roundCurrency(cpu),
+    ram: roundCurrency(ram),
+    volume: roundCurrency(volume),
+    egress: roundCurrency(egress),
+    usageSubtotal: roundCurrency(usageSubtotal),
+    total: roundCurrency(total),
+    minimumApplied: usageSubtotal < RAILWAY_RATE_CARD.minimumMonthlySpend,
+  };
+};
+
+export const calculateBreakEvenUtilization = ({
+  sealosMonthlyPrice,
+  cpu,
+  ram,
+  volume,
+  egress,
+}: {
+  sealosMonthlyPrice: number;
+  cpu: number;
+  ram: number;
+  volume: number;
+  egress: number;
+}): number | null => {
+  const fixedUsageCost =
+    clampToZero(volume) * RAILWAY_RATE_CARD.volumePerGbMonth +
+    clampToZero(egress) * RAILWAY_RATE_CARD.egressPerGb;
+  const fullComputeCost =
+    clampToZero(cpu) * RAILWAY_RATE_CARD.cpuPerVcpuMonth +
+    clampToZero(ram) * RAILWAY_RATE_CARD.ramPerGbMonth;
+
+  if (fullComputeCost === 0) return null;
+
+  return Math.max(
+    0,
+    Math.min(
+      100,
+      ((sealosMonthlyPrice - fixedUsageCost) / fullComputeCost) * 100,
+    ),
+  );
+};
+
+export const calculateCostDifference = (
+  sealosMonthlyPrice: number,
+  railwayMonthlyEstimate: number,
+) => {
+  const amount = roundCurrency(
+    Math.abs(railwayMonthlyEstimate - sealosMonthlyPrice),
+  );
+  const percentage =
+    railwayMonthlyEstimate === 0
+      ? 0
+      : Math.round((amount / railwayMonthlyEstimate) * 100);
+
+  return {
+    amount,
+    percentage,
+    lowerCost:
+      railwayMonthlyEstimate === sealosMonthlyPrice
+        ? ('equal' as const)
+        : railwayMonthlyEstimate > sealosMonthlyPrice
+          ? ('sealos' as const)
+          : ('railway' as const),
+  };
+};
+
+export const formatUsd = (value: number): string => {
+  const rounded = roundCurrency(value);
+  return `$${rounded.toLocaleString('en-US', {
+    minimumFractionDigits: Number.isInteger(rounded) ? 0 : 2,
+    maximumFractionDigits: 2,
+  })}`;
+};

--- a/app/[lang]/(home)/pricing/config/railway-cost.ts
+++ b/app/[lang]/(home)/pricing/config/railway-cost.ts
@@ -10,6 +10,8 @@ export const RAILWAY_RATE_CARD = {
   verifiedAt: '2026-07-24',
 } as const;
 
+export const DEFAULT_RAILWAY_UTILIZATION = 50;
+
 export interface RailwayCostInput {
   averageVcpu: number;
   averageRamGb: number;

--- a/app/[lang]/(home)/pricing/page.tsx
+++ b/app/[lang]/(home)/pricing/page.tsx
@@ -31,7 +31,7 @@ export function generateMetadata(): Metadata {
   return generatePageMetadata({
     title: 'Predictable Cloud Pricing',
     description:
-      'Compare Sealos monthly resource plans with a transparent Railway usage-based cost estimate.',
+      'Choose a fixed monthly Sealos resource package and compare it with a transparent Railway usage-based cost estimate.',
     pathname: '/pricing',
   });
 }
@@ -75,12 +75,12 @@ export default async function PricingPage({ params }: PageProps) {
             </p>
 
             <h1 className="mt-7 max-w-3xl text-5xl leading-[0.98] font-semibold text-balance sm:text-6xl lg:text-7xl">
-              Know what you’ll pay{' '}
+              Know your plan price{' '}
               <span className="text-blue-400">before you deploy.</span>
             </h1>
             <p className="text-muted-foreground mt-7 max-w-xl text-base leading-7 text-pretty sm:text-lg">
-              Choose a monthly resource package, then compare the same workload
-              with Railway’s usage-based pricing.
+              Choose a fixed monthly resource package, then estimate how the
+              same workload would be billed on Railway.
             </p>
             <div className="mt-9 flex flex-col items-start gap-5 sm:flex-row sm:items-center">
               <Button
@@ -97,12 +97,13 @@ export default async function PricingPage({ params }: PageProps) {
                 href="#railway-cost"
                 className="group inline-flex items-center py-2 text-sm font-medium text-zinc-200 transition-colors hover:text-white focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:outline-none motion-reduce:transition-none"
               >
-                Compare the same workload
+                Compare with Railway
                 <ArrowRight className="ml-2 size-4 transition-transform group-hover:translate-x-1 motion-reduce:transform-none motion-reduce:transition-none" />
               </a>
             </div>
             <p className="text-muted-foreground mt-7 max-w-lg text-sm leading-6">
-              Resource limits and cost assumptions are shown before purchase.
+              Your plan covers the resources listed below. Taxes and optional
+              services are shown separately before checkout.
             </p>
           </div>
 
@@ -116,13 +117,14 @@ export default async function PricingPage({ params }: PageProps) {
             />
             <div className="flex items-start justify-between gap-4">
               <div>
-                <p className="text-sm font-medium">Hobby cost example</p>
+                <p className="text-sm font-medium">Hobby workload example</p>
                 <p className="text-muted-foreground mt-1 text-xs">
-                  Same resources, different billing models
+                  Same workload inputs, different billing models
                 </p>
               </div>
-              <span className="border border-white/10 bg-white/5 px-2 py-1 text-xs text-zinc-300">
-                {DEFAULT_RAILWAY_UTILIZATION}% average use
+              <span className="max-w-48 border border-white/10 bg-white/5 px-2 py-1 text-right text-xs leading-5 text-zinc-300">
+                {DEFAULT_RAILWAY_UTILIZATION}% average CPU and RAM · full listed
+                volume and egress
               </span>
             </div>
 
@@ -135,7 +137,7 @@ export default async function PricingPage({ params }: PageProps) {
                   <div>
                     <p className="text-sm font-medium">Sealos Hobby</p>
                     <p className="text-muted-foreground mt-0.5 text-xs">
-                      Fixed resource package
+                      Known plan price
                     </p>
                   </div>
                 </div>
@@ -164,16 +166,17 @@ export default async function PricingPage({ params }: PageProps) {
             <div className="mt-6 grid gap-2 sm:grid-cols-[1fr_auto] sm:items-end">
               <div>
                 <p className="text-muted-foreground text-xs">
-                  Monthly difference
+                  Estimated monthly difference
                 </p>
                 <p className="mt-1 text-xl font-semibold tabular-nums">
-                  {formatUsd(heroDifference.amount)} lower with Sealos
+                  Sealos is {formatUsd(heroDifference.amount)} lower in this
+                  example.
                 </p>
               </div>
               <p className="text-muted-foreground text-xs sm:text-right">
-                4 vCPU · 4GB RAM
+                4 vCPU · 4Gi RAM
                 <br />
-                20GB volume · 50GB egress
+                20Gi volume · 50GB egress
               </p>
             </div>
           </aside>

--- a/app/[lang]/(home)/pricing/page.tsx
+++ b/app/[lang]/(home)/pricing/page.tsx
@@ -1,15 +1,18 @@
-import { PageTopRays } from '@/new-components/SideRays';
-import { GradientText } from '@/new-components/GradientText';
-import { FreeTrialCard } from './components/FreeTrialCard';
-import { PricingCard } from './components/PricingCard';
-import { MorePlans } from './components/MorePlans';
-import { FeaturesSection } from './components/FeaturesSection';
-import { FAQSection } from './components/FAQSection';
-import { mainPricingPlans } from './config/plans';
-import { generatePageMetadata } from '@/lib/utils/metadata';
-import Image from 'next/image';
-import HeroLinesImage from './assets/hero-lines.svg';
 import type { Metadata } from 'next';
+import Image from 'next/image';
+import { ArrowDown, ArrowRight, GitCompare } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { generatePageMetadata } from '@/lib/utils/metadata';
+import { GradientText } from '@/new-components/GradientText';
+import { PageTopRays } from '@/new-components/SideRays';
+import { FAQSection } from './components/FAQSection';
+import { FeaturesSection } from './components/FeaturesSection';
+import { FreeTrialCard } from './components/FreeTrialCard';
+import { MorePlans } from './components/MorePlans';
+import { PricingCard } from './components/PricingCard';
+import { RailwayCostCalculator } from './components/RailwayCostCalculator';
+import HeroLinesImage from './assets/hero-lines.svg';
+import { mainPricingPlans } from './config/plans';
 
 interface PageProps {
   params: Promise<{
@@ -19,22 +22,21 @@ interface PageProps {
 
 export function generateMetadata(): Metadata {
   return generatePageMetadata({
-    title: 'Pricing',
+    title: 'Predictable Cloud Pricing',
     description:
-      'Explore Sealos pricing plans with 7-day free trial and no credit card required.',
+      'Compare Sealos monthly resource plans with a transparent Railway usage-based cost estimate.',
     pathname: '/pricing',
   });
 }
 
 export default async function PricingPage({ params }: PageProps) {
   const { lang } = await params;
-  const langPrefix = `/${lang}`;
 
   return (
     <>
       <PageTopRays />
 
-      <section className="relative container -mt-24 pt-44 pb-18">
+      <section className="relative container -mt-24 pt-44 pb-20">
         <div className="pointer-events-none absolute inset-0 overflow-hidden">
           <Image
             src={HeroLinesImage}
@@ -44,48 +46,88 @@ export default async function PricingPage({ params }: PageProps) {
             priority
           />
         </div>
-        <div className="relative z-10">
-          <div className="mx-auto flex w-fit items-center gap-1.5 rounded-full border border-white/5 bg-white/5 px-3 py-1.5 text-center text-sm">
-            Choose the perfect plan for your needs. Always flexible to scale.
+        <div className="relative z-10 mx-auto flex max-w-4xl flex-col items-center">
+          <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-sm">
+            Predictable cloud pricing
           </div>
 
-          <h1
-            aria-label="7-Day free trial. No credit card required."
-            className="mt-9 mb-6 text-center text-3xl font-medium sm:text-5xl"
-          >
-            <span>
-              7-Day free trial
-              <br />
-              No credit{' '}
-            </span>
-            <GradientText>card required</GradientText>
+          <h1 className="mt-8 text-center text-4xl leading-tight font-semibold sm:text-6xl">
+            Know what you’ll pay
+            <br />
+            <GradientText>before you deploy.</GradientText>
           </h1>
-          <p className="text-muted-foreground text-center">
-            Whether you're a startup or an enterprise, our flexible plans evolve
-            with your needs, ensuring you always have the right tools to
-            succeed.
+          <p className="text-muted-foreground mt-6 max-w-2xl text-center text-base sm:text-lg">
+            Choose a monthly resource plan, then compare the same workload with
+            Railway’s usage-based pricing.
+          </p>
+          <div className="mt-8 flex w-full flex-col justify-center gap-3 sm:w-auto sm:flex-row">
+            <Button asChild variant="landing-primary" className="h-11 px-6">
+              <a href="#plans">
+                Choose your plan
+                <ArrowDown className="ml-2 size-4" />
+              </a>
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              className="h-11 rounded-full px-6"
+            >
+              <a href="#railway-cost">
+                <GitCompare className="mr-2 size-4" />
+                Compare with Railway
+              </a>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <section className="container pb-20">
+        <FreeTrialCard />
+      </section>
+
+      <section id="plans" className="container scroll-mt-24 pb-24">
+        <div className="mb-10 max-w-2xl">
+          <p className="text-sm font-medium text-blue-400">Monthly plans</p>
+          <h2 className="mt-3 text-3xl font-semibold sm:text-4xl">
+            Choose your resource package
+          </h2>
+          <p className="text-muted-foreground mt-4">
+            Every plan shows the CPU, memory, storage, traffic, and platform
+            credits included in its monthly price.
           </p>
         </div>
-      </section>
 
-      <section
-        className="container flex flex-col items-center gap-9 pb-18"
-        role="main"
-      >
-        <FreeTrialCard />
-
-        <div className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <div className="grid w-full grid-cols-1 gap-5 md:grid-cols-3">
           {mainPricingPlans.map((plan) => (
-            <PricingCard key={plan.name} plan={plan} />
+            <PricingCard key={plan.planId} plan={plan} />
           ))}
         </div>
-
-        <MorePlans />
       </section>
+
+      <RailwayCostCalculator lang={lang} />
+
+      <MorePlans />
 
       <FeaturesSection />
 
       <FAQSection />
+
+      <section className="container py-20">
+        <div className="flex flex-col items-start justify-between gap-8 border-y border-white/10 py-12 md:flex-row md:items-center">
+          <div className="max-w-2xl">
+            <p className="text-sm font-medium text-blue-400">Ready to deploy</p>
+            <h2 className="mt-3 text-3xl font-semibold">
+              Pick a resource package you can plan around.
+            </h2>
+          </div>
+          <Button asChild variant="landing-primary" className="h-11 px-6">
+            <a href="#plans">
+              Choose your plan
+              <ArrowRight className="ml-2 size-4" />
+            </a>
+          </Button>
+        </div>
+      </section>
     </>
   );
 }

--- a/app/[lang]/(home)/pricing/page.tsx
+++ b/app/[lang]/(home)/pricing/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from 'next';
 import Image from 'next/image';
-import { ArrowDown, ArrowRight, GitCompare } from 'lucide-react';
+import { ArrowDown, ArrowRight } from 'lucide-react';
+import RailwayIcon from '@/assets/platform-icons/railway.svg';
+import SealosIcon from '@/assets/shared-icons/sealos.svg';
 import { Button } from '@/components/ui/button';
 import { generatePageMetadata } from '@/lib/utils/metadata';
-import { GradientText } from '@/new-components/GradientText';
 import { PageTopRays } from '@/new-components/SideRays';
 import { FAQSection } from './components/FAQSection';
 import { FeaturesSection } from './components/FeaturesSection';
@@ -12,7 +13,12 @@ import { MorePlans } from './components/MorePlans';
 import { PricingCard } from './components/PricingCard';
 import { RailwayCostCalculator } from './components/RailwayCostCalculator';
 import HeroLinesImage from './assets/hero-lines.svg';
-import { mainPricingPlans } from './config/plans';
+import { mainPricingPlans, railwayComparablePlans } from './config/plans';
+import {
+  calculateCostDifference,
+  estimateRailwayMonthlyCost,
+  formatUsd,
+} from './config/railway-cost';
 
 interface PageProps {
   params: Promise<{
@@ -29,59 +35,152 @@ export function generateMetadata(): Metadata {
   });
 }
 
+const heroUtilization = 25;
+const heroPlan = railwayComparablePlans.find(
+  ({ planId }) => planId === 'hobby',
+)!;
+const heroRailwayEstimate = estimateRailwayMonthlyCost({
+  averageVcpu: heroPlan.resources.cpu * (heroUtilization / 100),
+  averageRamGb: heroPlan.resources.ram * (heroUtilization / 100),
+  volumeGb: heroPlan.resources.disk,
+  egressGb: heroPlan.resources.traffic,
+});
+const heroDifference = calculateCostDifference(
+  heroPlan.monthlyPrice,
+  heroRailwayEstimate.total,
+);
+
 export default async function PricingPage({ params }: PageProps) {
   const { lang } = await params;
 
   return (
-    <>
+    <main>
       <PageTopRays />
 
-      <section className="relative container -mt-24 pt-44 pb-20">
+      <section className="relative container -mt-24 overflow-hidden pt-40 pb-14 sm:pt-48 sm:pb-18">
         <div className="pointer-events-none absolute inset-0 overflow-hidden">
           <Image
             src={HeroLinesImage}
             alt=""
-            className="h-full w-full object-cover"
+            className="h-full w-full [mask-image:linear-gradient(to_bottom,black_55%,transparent)] object-cover opacity-70"
             fill
             priority
           />
         </div>
-        <div className="relative z-10 mx-auto flex max-w-4xl flex-col items-center">
-          <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-sm">
-            Predictable cloud pricing
+        <div className="relative z-10 grid items-end gap-12 lg:grid-cols-[minmax(0,1.08fr)_minmax(22rem,0.92fr)] lg:gap-16">
+          <div className="max-w-3xl">
+            <p className="flex items-center gap-2 text-sm font-medium text-zinc-300">
+              <span className="size-1.5 bg-blue-400" aria-hidden="true" />
+              Predictable cloud pricing
+            </p>
+
+            <h1 className="mt-7 max-w-3xl text-5xl leading-[0.98] font-semibold text-balance sm:text-6xl lg:text-7xl">
+              Know what you’ll pay{' '}
+              <span className="text-blue-400">before you deploy.</span>
+            </h1>
+            <p className="text-muted-foreground mt-7 max-w-xl text-base leading-7 text-pretty sm:text-lg">
+              Choose a monthly resource package, then compare the same workload
+              with Railway’s usage-based pricing.
+            </p>
+            <div className="mt-9 flex flex-col items-start gap-5 sm:flex-row sm:items-center">
+              <Button
+                asChild
+                variant="landing-primary"
+                className="h-11 rounded-md px-6 transition duration-200 active:translate-y-px motion-reduce:transition-none"
+              >
+                <a href="#plans">
+                  Choose your plan
+                  <ArrowDown className="ml-2 size-4" />
+                </a>
+              </Button>
+              <a
+                href="#railway-cost"
+                className="group inline-flex items-center py-2 text-sm font-medium text-zinc-200 transition-colors hover:text-white focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:outline-none motion-reduce:transition-none"
+              >
+                Compare the same workload
+                <ArrowRight className="ml-2 size-4 transition-transform group-hover:translate-x-1 motion-reduce:transform-none motion-reduce:transition-none" />
+              </a>
+            </div>
+            <p className="text-muted-foreground mt-7 max-w-lg text-sm leading-6">
+              Resource limits and cost assumptions are shown before purchase.
+            </p>
           </div>
 
-          <h1 className="mt-8 text-center text-4xl leading-tight font-semibold sm:text-6xl">
-            Know what you’ll pay
-            <br />
-            <GradientText>before you deploy.</GradientText>
-          </h1>
-          <p className="text-muted-foreground mt-6 max-w-2xl text-center text-base sm:text-lg">
-            Choose a monthly resource plan, then compare the same workload with
-            Railway’s usage-based pricing.
-          </p>
-          <div className="mt-8 flex w-full flex-col justify-center gap-3 sm:w-auto sm:flex-row">
-            <Button asChild variant="landing-primary" className="h-11 px-6">
-              <a href="#plans">
-                Choose your plan
-                <ArrowDown className="ml-2 size-4" />
-              </a>
-            </Button>
-            <Button
-              asChild
-              variant="outline"
-              className="h-11 rounded-full px-6"
-            >
-              <a href="#railway-cost">
-                <GitCompare className="mr-2 size-4" />
-                Compare with Railway
-              </a>
-            </Button>
-          </div>
+          <aside
+            aria-label="Default Hobby cost comparison"
+            className="relative overflow-hidden rounded-lg border border-blue-400/25 bg-zinc-950/80 p-6 shadow-[0_24px_80px_-36px_rgba(59,130,246,0.55)] backdrop-blur-sm sm:p-7"
+          >
+            <div
+              className="absolute inset-y-0 left-0 w-px bg-blue-400"
+              aria-hidden="true"
+            />
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium">Hobby cost example</p>
+                <p className="text-muted-foreground mt-1 text-xs">
+                  Same resources, different billing models
+                </p>
+              </div>
+              <span className="border border-white/10 bg-white/5 px-2 py-1 text-xs text-zinc-300">
+                {heroUtilization}% average use
+              </span>
+            </div>
+
+            <div className="mt-7 divide-y divide-white/10 border-y border-white/10">
+              <div className="flex items-center justify-between gap-5 py-5">
+                <div className="flex items-center gap-3">
+                  <span className="flex size-9 items-center justify-center rounded-md bg-white p-2">
+                    <Image src={SealosIcon} alt="" width={24} height={24} />
+                  </span>
+                  <div>
+                    <p className="text-sm font-medium">Sealos Hobby</p>
+                    <p className="text-muted-foreground mt-0.5 text-xs">
+                      Fixed resource package
+                    </p>
+                  </div>
+                </div>
+                <p className="text-2xl font-semibold tabular-nums">
+                  {formatUsd(heroPlan.monthlyPrice)}
+                </p>
+              </div>
+              <div className="flex items-center justify-between gap-5 py-5">
+                <div className="flex items-center gap-3">
+                  <span className="flex size-9 items-center justify-center rounded-md border border-white/10 bg-black p-2">
+                    <Image src={RailwayIcon} alt="" width={24} height={24} />
+                  </span>
+                  <div>
+                    <p className="text-sm font-medium">Railway</p>
+                    <p className="text-muted-foreground mt-0.5 text-xs">
+                      Usage estimate
+                    </p>
+                  </div>
+                </div>
+                <p className="text-2xl font-semibold tabular-nums">
+                  ~{formatUsd(heroRailwayEstimate.total)}
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-6 grid gap-2 sm:grid-cols-[1fr_auto] sm:items-end">
+              <div>
+                <p className="text-muted-foreground text-xs">
+                  Monthly difference
+                </p>
+                <p className="mt-1 text-xl font-semibold tabular-nums">
+                  {formatUsd(heroDifference.amount)} lower with Sealos
+                </p>
+              </div>
+              <p className="text-muted-foreground text-xs sm:text-right">
+                4 vCPU · 4GB RAM
+                <br />
+                20GB volume · 50GB egress
+              </p>
+            </div>
+          </aside>
         </div>
       </section>
 
-      <section className="container pb-20">
+      <section className="container pb-18">
         <FreeTrialCard />
       </section>
 
@@ -97,7 +196,7 @@ export default async function PricingPage({ params }: PageProps) {
           </p>
         </div>
 
-        <div className="grid w-full grid-cols-1 gap-5 md:grid-cols-3">
+        <div className="grid w-full grid-cols-1 gap-5 xl:grid-cols-3">
           {mainPricingPlans.map((plan) => (
             <PricingCard key={plan.planId} plan={plan} />
           ))}
@@ -111,23 +210,6 @@ export default async function PricingPage({ params }: PageProps) {
       <FeaturesSection />
 
       <FAQSection />
-
-      <section className="container py-20">
-        <div className="flex flex-col items-start justify-between gap-8 border-y border-white/10 py-12 md:flex-row md:items-center">
-          <div className="max-w-2xl">
-            <p className="text-sm font-medium text-blue-400">Ready to deploy</p>
-            <h2 className="mt-3 text-3xl font-semibold">
-              Pick a resource package you can plan around.
-            </h2>
-          </div>
-          <Button asChild variant="landing-primary" className="h-11 px-6">
-            <a href="#plans">
-              Choose your plan
-              <ArrowRight className="ml-2 size-4" />
-            </a>
-          </Button>
-        </div>
-      </section>
-    </>
+    </main>
   );
 }

--- a/app/[lang]/(home)/pricing/page.tsx
+++ b/app/[lang]/(home)/pricing/page.tsx
@@ -15,6 +15,7 @@ import { RailwayCostCalculator } from './components/RailwayCostCalculator';
 import HeroLinesImage from './assets/hero-lines.svg';
 import { mainPricingPlans, railwayComparablePlans } from './config/plans';
 import {
+  DEFAULT_RAILWAY_UTILIZATION,
   calculateCostDifference,
   estimateRailwayMonthlyCost,
   formatUsd,
@@ -35,13 +36,12 @@ export function generateMetadata(): Metadata {
   });
 }
 
-const heroUtilization = 25;
 const heroPlan = railwayComparablePlans.find(
   ({ planId }) => planId === 'hobby',
 )!;
 const heroRailwayEstimate = estimateRailwayMonthlyCost({
-  averageVcpu: heroPlan.resources.cpu * (heroUtilization / 100),
-  averageRamGb: heroPlan.resources.ram * (heroUtilization / 100),
+  averageVcpu: heroPlan.resources.cpu * (DEFAULT_RAILWAY_UTILIZATION / 100),
+  averageRamGb: heroPlan.resources.ram * (DEFAULT_RAILWAY_UTILIZATION / 100),
   volumeGb: heroPlan.resources.disk,
   egressGb: heroPlan.resources.traffic,
 });
@@ -122,7 +122,7 @@ export default async function PricingPage({ params }: PageProps) {
                 </p>
               </div>
               <span className="border border-white/10 bg-white/5 px-2 py-1 text-xs text-zinc-300">
-                {heroUtilization}% average use
+                {DEFAULT_RAILWAY_UTILIZATION}% average use
               </span>
             </div>
 

--- a/content/docs/guides/devbox/intro.en.mdx
+++ b/content/docs/guides/devbox/intro.en.mdx
@@ -67,8 +67,8 @@ Sealos uses simple subscription pricing with four tiers:
 
 | Plan | Price | Resources |
 |------|-------|----------|
-| Starter | $7/month | 2 vCPU, 2Gi RAM, 1Gi Disk |
-| Hobby | $25/month | 4 vCPU, 4Gi RAM, 10Gi Disk |
+| Starter | $7/month | 2 vCPU, 2Gi RAM, 10Gi Disk |
+| Hobby | $25/month | 4 vCPU, 4Gi RAM, 20Gi Disk |
 | Pro | $512/month | 16 vCPU, 32Gi RAM, 200Gi Disk |
 | Team | $2,030/month | 64 vCPU, 128Gi RAM, 500Gi Disk |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1052,6 +1052,7 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-3.1.0.tgz",
       "integrity": "sha512-xU/lwKdOyfXtQGqn3VnJjlDrmKXEvMi1mgYxVmukEUtVycIz1nh7oQ40bKTd4cA7rLStqu0740pnhGYxGoqsCg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "source-map": "^0.7.0"
@@ -1110,6 +1111,7 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.0.tgz",
       "integrity": "sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -4582,6 +4584,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
       "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4593,6 +4596,7 @@
       "integrity": "sha512-nf22//wEbKXusP6E9pfOCDwFdHAX4u172eaJI4YkDRQEZiorm6KfYnSC2SWLDMVWUOWPERmJnN0ujeAfTBLvrw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4636,6 +4640,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5186,6 +5191,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5586,6 +5592,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6178,6 +6185,7 @@
       "resolved": "https://registry.npmmirror.com/fumadocs-core/-/fumadocs-core-15.2.8.tgz",
       "integrity": "sha512-+ySqGximB5/6Tu2/g+r0muAN9DJUfScBhTqxdlpFyie2K5sprYbak0aMWXHzHoGDOVu/IbYpSGwe6r7XkdYAsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/intl-localematcher": "^0.6.1",
         "@orama/orama": "^3.1.6",
@@ -8481,6 +8489,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.28.tgz",
       "integrity": "sha512-QLEIP/kYXynIxtcKB6vNjtWLVs3Y4Sb+EClTC/CSVzdLD1gIuItccpu/n1lhmduffI32iPGEK2cLLxxt28qgYA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "14.2.28",
         "@swc/helpers": "0.5.5",
@@ -8864,6 +8873,7 @@
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9024,6 +9034,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9048,6 +9059,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9948,7 +9960,8 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.3.tgz",
       "integrity": "sha512-2Q+rw9vy1WFXu5cIxlvsabCwhU2qUwodGq03ODhLJ0jW4ek5BUtoCsnLB0qG+m8AHgEsSJcJGDSDe06FXlP74g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animated": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "lint": "rm -f tsconfig.tsbuildinfo && tsc --noEmit",
+    "test:pricing": "node --test scripts/railway-cost.test.js",
     "build": "next build && node scripts/normalize-root-locale.js",
     "validate-tutorials": "node scripts/validate-tutorials.mjs",
     "build:analyze": "ANALYZE=true next build && node scripts/normalize-root-locale.js",

--- a/scripts/railway-cost.test.js
+++ b/scripts/railway-cost.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 
 const {
+  DEFAULT_RAILWAY_UTILIZATION,
   RAILWAY_RATE_CARD,
   calculateBreakEvenUtilization,
   calculateCostDifference,
@@ -19,14 +20,23 @@ const estimatePlan = ({ cpu, ram, disk, traffic }, utilization) =>
 test('uses the verified Railway rate card', () => {
   assert.deepEqual(
     {
-      minimum: RAILWAY_RATE_CARD.minimumMonthlySpend,
+      hobbySubscription: RAILWAY_RATE_CARD.hobbyMonthlySubscription,
+      hobbyIncludedUsage: RAILWAY_RATE_CARD.hobbyIncludedUsage,
       cpu: RAILWAY_RATE_CARD.cpuPerVcpuMonth,
       ram: RAILWAY_RATE_CARD.ramPerGbMonth,
       volume: RAILWAY_RATE_CARD.volumePerGbMonth,
       egress: RAILWAY_RATE_CARD.egressPerGb,
     },
-    { minimum: 5, cpu: 20, ram: 10, volume: 0.15, egress: 0.05 },
+    {
+      hobbySubscription: 5,
+      hobbyIncludedUsage: 5,
+      cpu: 20,
+      ram: 10,
+      volume: 0.15,
+      egress: 0.05,
+    },
   );
+  assert.equal(DEFAULT_RAILWAY_UTILIZATION, 50);
 });
 
 test('estimates Starter at 10%, 25%, 50%, and 100% utilization', () => {
@@ -47,7 +57,7 @@ test('estimates Hobby at 10%, 25%, 50%, and 100% utilization', () => {
   );
 });
 
-test('applies the Railway minimum monthly usage', () => {
+test('applies the Railway Hobby subscription minimum', () => {
   const estimate = estimateRailwayMonthlyCost({
     averageVcpu: 0,
     averageRamGb: 0,
@@ -66,8 +76,13 @@ test('reports either platform as the lower-cost result', () => {
   });
   assert.deepEqual(calculateCostDifference(25, 17.5), {
     amount: 7.5,
-    percentage: 43,
+    percentage: 30,
     lowerCost: 'railway',
+  });
+  assert.deepEqual(calculateCostDifference(25, 25), {
+    amount: 0,
+    percentage: 0,
+    lowerCost: 'equal',
   });
 });
 

--- a/scripts/railway-cost.test.js
+++ b/scripts/railway-cost.test.js
@@ -1,0 +1,95 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  RAILWAY_RATE_CARD,
+  calculateBreakEvenUtilization,
+  calculateCostDifference,
+  estimateRailwayMonthlyCost,
+} = require('../app/[lang]/(home)/pricing/config/railway-cost.ts');
+
+const estimatePlan = ({ cpu, ram, disk, traffic }, utilization) =>
+  estimateRailwayMonthlyCost({
+    averageVcpu: cpu * utilization,
+    averageRamGb: ram * utilization,
+    volumeGb: disk,
+    egressGb: traffic,
+  }).total;
+
+test('uses the verified Railway rate card', () => {
+  assert.deepEqual(
+    {
+      minimum: RAILWAY_RATE_CARD.minimumMonthlySpend,
+      cpu: RAILWAY_RATE_CARD.cpuPerVcpuMonth,
+      ram: RAILWAY_RATE_CARD.ramPerGbMonth,
+      volume: RAILWAY_RATE_CARD.volumePerGbMonth,
+      egress: RAILWAY_RATE_CARD.egressPerGb,
+    },
+    { minimum: 5, cpu: 20, ram: 10, volume: 0.15, egress: 0.05 },
+  );
+});
+
+test('estimates Starter at 10%, 25%, 50%, and 100% utilization', () => {
+  const starter = { cpu: 2, ram: 2, disk: 10, traffic: 10 };
+  assert.deepEqual(
+    [0.1, 0.25, 0.5, 1].map((utilization) =>
+      estimatePlan(starter, utilization),
+    ),
+    [8, 17, 32, 62],
+  );
+});
+
+test('estimates Hobby at 10%, 25%, 50%, and 100% utilization', () => {
+  const hobby = { cpu: 4, ram: 4, disk: 20, traffic: 50 };
+  assert.deepEqual(
+    [0.1, 0.25, 0.5, 1].map((utilization) => estimatePlan(hobby, utilization)),
+    [17.5, 35.5, 65.5, 125.5],
+  );
+});
+
+test('applies the Railway minimum monthly usage', () => {
+  const estimate = estimateRailwayMonthlyCost({
+    averageVcpu: 0,
+    averageRamGb: 0,
+    volumeGb: 0,
+    egressGb: 0,
+  });
+  assert.equal(estimate.total, 5);
+  assert.equal(estimate.minimumApplied, true);
+});
+
+test('reports either platform as the lower-cost result', () => {
+  assert.deepEqual(calculateCostDifference(25, 35.5), {
+    amount: 10.5,
+    percentage: 30,
+    lowerCost: 'sealos',
+  });
+  assert.deepEqual(calculateCostDifference(25, 17.5), {
+    amount: 7.5,
+    percentage: 43,
+    lowerCost: 'railway',
+  });
+});
+
+test('calculates the Starter and Hobby cost crossover points', () => {
+  assert.equal(
+    calculateBreakEvenUtilization({
+      sealosMonthlyPrice: 7,
+      cpu: 2,
+      ram: 2,
+      volume: 10,
+      egress: 10,
+    })?.toFixed(1),
+    '8.3',
+  );
+  assert.equal(
+    calculateBreakEvenUtilization({
+      sealosMonthlyPrice: 25,
+      cpu: 4,
+      ram: 4,
+      volume: 20,
+      egress: 50,
+    })?.toFixed(1),
+    '16.3',
+  );
+});

--- a/tests/rybbit-cta.test.ts
+++ b/tests/rybbit-cta.test.ts
@@ -2,10 +2,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import test from 'node:test';
-import {
-  getRybbitCtaProps,
-  toRybbitCtaId,
-} from '../lib/analytics/rybbit-cta.ts';
+import { getRybbitCtaProps, toRybbitCtaId } from '../lib/analytics/rybbit-cta';
 
 const root = process.cwd();
 
@@ -61,7 +58,7 @@ const pricingCtas = [
   },
   {
     file: 'app/[lang]/(home)/pricing/components/MorePlans.tsx',
-    idSource: 'id: `pricing_${toRybbitCtaId(selectedPlan.name)}_get_started`',
+    idSource: 'id: `pricing_${toRybbitCtaId(plan.name)}_get_started`',
   },
 ];
 


### PR DESCRIPTION
## Summary

- Clarify Sealos fixed monthly plan pricing, resource limits, new-user offer eligibility, and checkout boundaries.
- Align Railway Hobby messaging with the official $5/month subscription including $5 of resource usage.
- Keep the Railway calculator default at 50% CPU and RAM utilization, with transparent assumptions, symmetric cost differences, and updated source verification.
- Synchronize pricing, FAQ, comparison, trial, and DevBox resource copy.

## Details

- Add regular-price and new-user-price labels to Starter and Hobby plan cards.
- Update plan descriptions, the Hobby recommendation banner, trial resource details, and the Custom plan label.
- Split Railway subscription and included-usage fields in the shared rate card.
- Use the higher monthly cost as the denominator for comparison percentages.
- Clarify break-even labels, Gi versus GB units, rate sources, and Railway plan-limit caveats.
- Add the new-user pricing FAQ and update plan-boundary, payment, and Railway billing answers.

## Validation

- `npm run test:pricing`
- `npm run lint`
- `npx next build` (Node 20)
- `git diff --check`
- Browser checks at 1440px, 1024px, and 390px, including 10% and 50% utilization states, plan offers, FAQ expansion, and horizontal-overflow checks.
