### PR TITLE
feat(analytics): add consent-safe Google Ads attribution

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -2,6 +2,7 @@ import { locales } from '@/lib/i18n';
 import { RootProvider } from 'fumadocs-ui/provider';
 import type { ReactNode } from 'react';
 import { Analytics } from '@/components/analytics';
+import { ConsentModeDefault } from '@/components/analytics/consent-mode-default';
 import { GTMBody } from '@/components/analytics/gtm-body';
 import { generatePageMetadata } from '@/lib/utils/metadata';
 import StructuredDataComponent from '@/components/structured-data';
@@ -38,6 +39,7 @@ export default async function LocaleLayout({
   return (
     <html lang={htmlLang} className={htmlClassName} suppressHydrationWarning>
       <head>
+        <ConsentModeDefault />
         {/* Favicon and App Icons */}
         <link
           rel="icon"

--- a/components/analytics/consent-mode-default.tsx
+++ b/components/analytics/consent-mode-default.tsx
@@ -1,0 +1,44 @@
+import { analyticsConfig } from '@/config/analytics';
+
+const consentModeDefaults = `
+window.dataLayer = window.dataLayer || [];
+window.__sealosConsent = window.__sealosConsent || {
+  ad_storage: 'denied',
+  analytics_storage: 'denied',
+  ad_user_data: 'denied',
+  ad_personalization: 'denied'
+};
+function gtag(){window.dataLayer.push(arguments);}
+gtag('consent', 'default', {
+  ad_storage: 'denied',
+  analytics_storage: 'denied',
+  ad_user_data: 'denied',
+  ad_personalization: 'denied',
+  wait_for_update: 500
+});
+window.__sealosUpdateConsent = window.__sealosUpdateConsent || function(update) {
+  update = update || {};
+  var next = {
+    ad_storage: update.ad_storage === 'granted' ? 'granted' : 'denied',
+    analytics_storage: update.analytics_storage === 'granted' ? 'granted' : 'denied',
+    ad_user_data: update.ad_user_data === 'granted' ? 'granted' : 'denied',
+    ad_personalization: update.ad_personalization === 'granted' ? 'granted' : 'denied'
+  };
+  window.__sealosConsent = next;
+  gtag('consent', 'update', next);
+  window.dataLayer.push({ event: 'consent_update', ...next });
+};
+`;
+
+export function ConsentModeDefault() {
+  if (!analyticsConfig.gtm?.enabled || !analyticsConfig.gtm.containerId) {
+    return null;
+  }
+
+  return (
+    <script
+      id="consent-mode-default"
+      dangerouslySetInnerHTML={{ __html: consentModeDefaults }}
+    />
+  );
+}

--- a/components/analytics/index.tsx
+++ b/components/analytics/index.tsx
@@ -33,90 +33,6 @@ const loadRybbitAnalytics = (siteId: string) => {
 };
 
 export function Analytics() {
-  // GTM Implementation with smart lazy loading
-  useEffect(() => {
-    if (analyticsConfig.gtm?.enabled && analyticsConfig.gtm.containerId) {
-      // Avoid duplicate GTM initialization
-      if (
-        window.dataLayer &&
-        window.dataLayer.find((item) => item['gtm.start'])
-      ) {
-        return;
-      }
-
-      // Initialize dataLayer immediately
-      window.dataLayer = window.dataLayer || [];
-
-      let gtmLoaded = false;
-
-      const loadGTM = () => {
-        if (gtmLoaded) return;
-        gtmLoaded = true;
-
-        window.dataLayer.push({
-          'gtm.start': new Date().getTime(),
-          event: 'gtm.js',
-        });
-
-        // Load GTM script
-        const script = document.createElement('script');
-        script.async = true;
-        script.src = `https://www.googletagmanager.com/gtm.js?id=${analyticsConfig.gtm!.containerId}`;
-        script.onerror = () => {
-          console.warn('Failed to load Google Tag Manager');
-        };
-
-        const firstScript = document.getElementsByTagName('script')[0];
-        firstScript?.parentNode?.insertBefore(script, firstScript);
-      };
-
-      // Strategy 1: Load on user interaction (scroll, click, or touch)
-      const interactionEvents = [
-        'scroll',
-        'mousedown',
-        'touchstart',
-        'keydown',
-      ];
-      let interactionTriggered = false;
-
-      const handleInteraction = () => {
-        if (!interactionTriggered) {
-          interactionTriggered = true;
-          // Small delay to ensure interaction doesn't block
-          setTimeout(loadGTM, 100);
-
-          // Remove all listeners once triggered
-          interactionEvents.forEach((event) => {
-            window.removeEventListener(event, handleInteraction);
-          });
-        }
-      };
-
-      // Add interaction listeners
-      interactionEvents.forEach((event) => {
-        window.addEventListener(event, handleInteraction, {
-          passive: true,
-          once: true,
-        });
-      });
-
-      // Strategy 2: Fallback - load after 5 seconds if no interaction
-      const fallbackTimer = setTimeout(() => {
-        if (!gtmLoaded) {
-          loadGTM();
-        }
-      }, 5000);
-
-      // Cleanup
-      return () => {
-        clearTimeout(fallbackTimer);
-        interactionEvents.forEach((event) => {
-          window.removeEventListener(event, handleInteraction);
-        });
-      };
-    }
-  }, []);
-
   // Lazy load Clarity after page is fully loaded (only for zh-cn now)
   useEffect(() => {
     if (analyticsConfig.clarity?.enabled) {
@@ -143,7 +59,23 @@ export function Analytics() {
 
   return (
     <>
-      {/* Google Tag Manager is now loaded via useEffect with smart lazy loading */}
+      {analyticsConfig.gtm?.enabled && analyticsConfig.gtm.containerId && (
+        <>
+          <Script strategy="afterInteractive" id="google-tag-manager-init">
+            {`
+              window.dataLayer = window.dataLayer || [];
+              if (!window.dataLayer.some(function(item) { return item && item['gtm.start']; })) {
+                window.dataLayer.push({ 'gtm.start': Date.now(), event: 'gtm.js' });
+              }
+            `}
+          </Script>
+          <Script
+            strategy="afterInteractive"
+            id="google-tag-manager"
+            src={`https://www.googletagmanager.com/gtm.js?id=${analyticsConfig.gtm.containerId}`}
+          />
+        </>
+      )}
 
       {/* Baidu Analytics - for zh-cn */}
       {analyticsConfig.baidu?.enabled && (

--- a/hooks/use-auth-redirect.ts
+++ b/hooks/use-auth-redirect.ts
@@ -4,6 +4,7 @@ import { useCallback } from 'react';
 import { siteConfig } from '@/config/site';
 import { verifySharedAuth } from '@/lib/utils/shared-auth';
 import { useOpenAuthForm } from '@/new-components/AuthForm/AuthFormContext';
+import { appendAttributionToUrl } from '@/lib/attribution';
 
 export function buildAuthRedirectUrl(params?: Record<string, string>) {
   const target = new URL(siteConfig.oauth2Url);
@@ -14,7 +15,7 @@ export function buildAuthRedirectUrl(params?: Record<string, string>) {
     });
   }
 
-  return target.toString();
+  return appendAttributionToUrl(target).toString();
 }
 
 export function useAuthRedirect() {

--- a/lib/attribution.test.mts
+++ b/lib/attribution.test.mts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import test, { afterEach, beforeEach } from 'node:test';
+
+import {
+  ATTRIBUTION_STORAGE_KEY,
+  appendAttributionToUrl,
+  decodeAttributionState,
+  getAttributionState,
+} from './attribution.ts';
+
+class MemoryStorage {
+  private values = new Map<string, string>();
+
+  clear() {
+    this.values.clear();
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+const localStorage = new MemoryStorage();
+const browser = {
+  __sealosAttribution: undefined,
+  __sealosConsent: {
+    ad_personalization: 'denied',
+    ad_storage: 'denied',
+    ad_user_data: 'denied',
+    analytics_storage: 'denied',
+  },
+  atob,
+  btoa,
+  localStorage,
+  location: { href: 'https://sealos.io/' },
+};
+
+const originalDocument = Object.getOwnPropertyDescriptor(
+  globalThis,
+  'document',
+);
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+function restoreGlobal(
+  name: 'document' | 'window',
+  descriptor: PropertyDescriptor | undefined,
+) {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(globalThis, name);
+}
+
+beforeEach(() => {
+  Object.assign(globalThis, {
+    document: { referrer: '' },
+    window: browser,
+  });
+});
+
+afterEach(() => {
+  restoreGlobal('document', originalDocument);
+  restoreGlobal('window', originalWindow);
+});
+
+function reset(href: string, consent: 'denied' | 'granted') {
+  localStorage.clear();
+  browser.location.href = href;
+  browser.__sealosConsent.ad_user_data = consent;
+}
+
+test('denied consent records campaign context without the click ID value', () => {
+  reset(
+    'https://sealos.io/?gclid=denied-click&utm_campaign=deploy&utm_source=google',
+    'denied',
+  );
+
+  const state = getAttributionState();
+
+  assert.equal(state?.ad_user_data_consent, false);
+  assert.equal(state?.first_touch?.click_id_present, true);
+  assert.equal(state?.first_touch?.click_id_value, '');
+  assert.doesNotMatch(
+    localStorage.getItem(ATTRIBUTION_STORAGE_KEY) ?? '',
+    /denied-click/,
+  );
+});
+
+test('granted consent carries one click ID through sea_attr', () => {
+  reset(
+    'https://sealos.io/?gclid=granted-click&utm_campaign=deploy&utm_source=google',
+    'granted',
+  );
+
+  const target = appendAttributionToUrl(new URL('https://cloud.sealos.io/'));
+  const encoded = target.searchParams.get('sea_attr');
+  const state = encoded ? decodeAttributionState(encoded) : null;
+
+  assert.equal(state?.ad_user_data_consent, true);
+  assert.equal(state?.first_touch?.click_id_value, 'granted-click');
+});
+
+test('granting consent recovers a click ID recorded while consent was denied', () => {
+  reset(
+    'https://sealos.io/?gclid=consent-later&utm_campaign=deploy&utm_source=google',
+    'denied',
+  );
+  assert.equal(getAttributionState()?.first_touch?.click_id_value, '');
+
+  browser.__sealosConsent.ad_user_data = 'granted';
+  const state = getAttributionState();
+
+  assert.equal(state?.ad_user_data_consent, true);
+  assert.equal(state?.first_touch?.click_id_value, 'consent-later');
+  assert.match(
+    localStorage.getItem(ATTRIBUTION_STORAGE_KEY) ?? '',
+    /consent-later/,
+  );
+});
+
+test('withdrawing consent redacts a previously stored click ID', () => {
+  reset('https://sealos.io/?wbraid=stored-click', 'granted');
+  assert.equal(
+    getAttributionState()?.first_touch?.click_id_value,
+    'stored-click',
+  );
+
+  browser.__sealosConsent.ad_user_data = 'denied';
+  browser.location.href = 'https://sealos.io/pricing/';
+  const state = getAttributionState();
+
+  assert.equal(state?.ad_user_data_consent, false);
+  assert.equal(state?.first_touch?.click_id_value, '');
+  assert.doesNotMatch(
+    localStorage.getItem(ATTRIBUTION_STORAGE_KEY) ?? '',
+    /stored-click/,
+  );
+});

--- a/lib/attribution.ts
+++ b/lib/attribution.ts
@@ -1,0 +1,265 @@
+export const ATTRIBUTION_STORAGE_KEY = 'sealos_attr_v2';
+export const ATTRIBUTION_URL_PARAM = 'sea_attr';
+
+export type GoogleClickIdType = 'gclid' | 'gbraid' | 'wbraid';
+
+export interface AttributionTouch {
+  campaign: string;
+  channel: string;
+  click_id_present: boolean;
+  click_id_type: string;
+  click_id_value: string;
+  content: string;
+  direct: boolean;
+  landing_hostname: string;
+  landing_path: string;
+  medium: string;
+  referrer_domain: string;
+  source: string;
+  term: string;
+  ts: string;
+}
+
+export interface AttributionState {
+  ad_user_data_consent: boolean;
+  first_touch?: AttributionTouch;
+  last_qualified_touch?: AttributionTouch;
+  last_touch?: AttributionTouch;
+  version: 2;
+}
+
+interface SealosConsentState {
+  ad_personalization?: 'denied' | 'granted';
+  ad_storage?: 'denied' | 'granted';
+  ad_user_data?: 'denied' | 'granted';
+  analytics_storage?: 'denied' | 'granted';
+}
+
+interface SealosAttributionApi {
+  encode: () => string;
+  getState: () => AttributionState;
+  refresh: () => AttributionState;
+}
+
+const CLICK_ID_KEYS: GoogleClickIdType[] = ['gclid', 'gbraid', 'wbraid'];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isAttributionState(value: unknown): value is AttributionState {
+  return isRecord(value) && value.version === 2;
+}
+
+function redactTouchClickId(
+  touch: AttributionTouch | undefined,
+): AttributionTouch | undefined {
+  return touch ? { ...touch, click_id_value: '' } : undefined;
+}
+
+function withConsent(
+  state: AttributionState,
+  adUserDataConsent: boolean,
+): AttributionState {
+  return {
+    ...state,
+    ad_user_data_consent: adUserDataConsent,
+    ...(adUserDataConsent
+      ? {}
+      : {
+          first_touch: redactTouchClickId(state.first_touch),
+          last_qualified_touch: redactTouchClickId(state.last_qualified_touch),
+          last_touch: redactTouchClickId(state.last_touch),
+        }),
+  };
+}
+
+function withCurrentConsent(state: AttributionState): AttributionState {
+  return withConsent(state, window.__sealosConsent?.ad_user_data === 'granted');
+}
+
+function parseState(raw: string | null): AttributionState | null {
+  try {
+    const value = raw ? JSON.parse(raw) : null;
+    return isAttributionState(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function encodeUtf8(value: string): string {
+  return encodeURIComponent(value).replace(/%([0-9A-F]{2})/g, (_, hex) =>
+    String.fromCharCode(Number.parseInt(hex, 16)),
+  );
+}
+
+export function encodeAttributionState(state: AttributionState): string {
+  try {
+    const consentSafeState = withConsent(
+      state,
+      state.ad_user_data_consent === true,
+    );
+    return window
+      .btoa(encodeUtf8(JSON.stringify(consentSafeState)))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+  } catch {
+    return '';
+  }
+}
+
+export function decodeAttributionState(value: string): AttributionState | null {
+  try {
+    let normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+    while (normalized.length % 4) normalized += '=';
+    const binary = window.atob(normalized);
+    let encoded = '';
+    for (let index = 0; index < binary.length; index += 1) {
+      encoded += `%${binary.charCodeAt(index).toString(16).padStart(2, '0')}`;
+    }
+    const state = JSON.parse(decodeURIComponent(encoded));
+    return isAttributionState(state) ? state : null;
+  } catch {
+    return null;
+  }
+}
+
+function referrerDomain(): string {
+  try {
+    return document.referrer
+      ? new URL(document.referrer).hostname.replace(/^www\./, '')
+      : '';
+  } catch {
+    return '';
+  }
+}
+
+function currentTouch(url: URL): AttributionTouch {
+  const clickIdType = CLICK_ID_KEYS.find((key) => url.searchParams.has(key));
+  const clickIdValue = clickIdType
+    ? url.searchParams.get(clickIdType) || ''
+    : '';
+  const canStoreClickId = window.__sealosConsent?.ad_user_data === 'granted';
+  const source =
+    url.searchParams.get('utm_source') || (clickIdType ? 'google' : 'direct');
+  const medium =
+    url.searchParams.get('utm_medium') || (clickIdType ? 'paid' : 'none');
+  const direct = source === 'direct';
+
+  return {
+    campaign: url.searchParams.get('utm_campaign') || '',
+    channel: clickIdType ? 'paid_search' : direct ? 'direct' : 'campaign',
+    click_id_present: Boolean(clickIdType),
+    click_id_type: clickIdType || '',
+    click_id_value: canStoreClickId ? clickIdValue : '',
+    content: url.searchParams.get('utm_content') || '',
+    direct,
+    landing_hostname: url.hostname,
+    landing_path: url.pathname,
+    medium,
+    referrer_domain: referrerDomain(),
+    source,
+    term: url.searchParams.get('utm_term') || '',
+    ts: new Date().toISOString(),
+  };
+}
+
+function recoverRedactedClickId(
+  existing: AttributionTouch | undefined,
+  candidates: readonly (AttributionTouch | undefined)[],
+): AttributionTouch | undefined {
+  if (!existing || existing.click_id_value || !existing.click_id_present) {
+    return existing;
+  }
+
+  const candidate = candidates.find(
+    (touch) =>
+      touch?.click_id_value &&
+      touch.click_id_type === existing.click_id_type &&
+      touch.source === existing.source &&
+      touch.campaign === existing.campaign &&
+      touch.medium === existing.medium &&
+      touch.landing_hostname === existing.landing_hostname &&
+      touch.landing_path === existing.landing_path,
+  );
+
+  return candidate
+    ? { ...existing, click_id_value: candidate.click_id_value }
+    : existing;
+}
+
+function mergeAttributionState(
+  stored: AttributionState | null,
+  inbound: AttributionState | null,
+  touch: AttributionTouch,
+): AttributionState {
+  const firstTouch =
+    recoverRedactedClickId(stored?.first_touch, [
+      inbound?.first_touch,
+      touch,
+    ]) ||
+    recoverRedactedClickId(inbound?.first_touch, [touch]) ||
+    touch;
+  const lastTouch = touch.direct
+    ? stored?.last_touch || inbound?.last_touch || touch
+    : touch;
+  const lastQualifiedTouch = touch.direct
+    ? stored?.last_qualified_touch ||
+      inbound?.last_qualified_touch ||
+      firstTouch
+    : touch;
+
+  return {
+    ad_user_data_consent: window.__sealosConsent?.ad_user_data === 'granted',
+    first_touch: firstTouch,
+    last_qualified_touch: lastQualifiedTouch,
+    last_touch: lastTouch,
+    version: 2,
+  };
+}
+
+function browserAttributionApi(): SealosAttributionApi | undefined {
+  return window.__sealosAttribution;
+}
+
+export function getAttributionState(): AttributionState | null {
+  if (typeof window === 'undefined') return null;
+
+  const apiState = browserAttributionApi()?.getState();
+  if (isAttributionState(apiState)) {
+    const state = withCurrentConsent(apiState);
+    window.localStorage.setItem(ATTRIBUTION_STORAGE_KEY, JSON.stringify(state));
+    return state;
+  }
+
+  const url = new URL(window.location.href);
+  const stored = parseState(
+    window.localStorage.getItem(ATTRIBUTION_STORAGE_KEY),
+  );
+  const inboundValue = url.searchParams.get(ATTRIBUTION_URL_PARAM);
+  const inbound = inboundValue ? decodeAttributionState(inboundValue) : null;
+  const state = withCurrentConsent(
+    mergeAttributionState(stored, inbound, currentTouch(url)),
+  );
+  window.localStorage.setItem(ATTRIBUTION_STORAGE_KEY, JSON.stringify(state));
+  return state;
+}
+
+export function appendAttributionToUrl(target: URL): URL {
+  if (typeof window === 'undefined') return target;
+
+  const state = getAttributionState();
+  const encoded = state ? encodeAttributionState(state) : '';
+
+  if (encoded) target.searchParams.set(ATTRIBUTION_URL_PARAM, encoded);
+  return target;
+}
+
+declare global {
+  interface Window {
+    __sealosAttribution?: SealosAttributionApi;
+    __sealosConsent?: SealosConsentState;
+    __sealosUpdateConsent?: (update: SealosConsentState) => void;
+  }
+}

--- a/lib/gtm.ts
+++ b/lib/gtm.ts
@@ -1,6 +1,55 @@
 export interface GTMEvent {
   event: string;
-  [key: string]: any;
+  [key: string]: unknown;
+}
+
+export type MarketingEventName =
+  | 'build_started'
+  | 'deploy_success'
+  | 'running_24h'
+  | 'new_subscription'
+  | 'topup_success';
+
+export interface MarketingTouchpoint {
+  campaign?: string;
+  channel?: string;
+  click_id_type?: string;
+  click_id_value?: string;
+  content?: string;
+  landing_hostname?: string;
+  landing_path?: string;
+  medium?: string;
+  source?: string;
+  term?: string;
+  ts?: string;
+}
+
+export interface MarketingLifecycleEvent extends GTMEvent {
+  ad_user_data_consent: boolean;
+  deployment_id: string | null;
+  event: MarketingEventName;
+  event_id: string;
+  first_touch: MarketingTouchpoint | null;
+  gbraid: string | null;
+  gclid: string | null;
+  hashed_user_data?: MarketingHashedUserData;
+  last_touch: MarketingTouchpoint | null;
+  occurred_at: string;
+  user_id: string | null;
+  wbraid: string | null;
+  workspace_id: string | null;
+}
+
+export interface MarketingHashedUserData {
+  email_sha256?: string;
+  phone_sha256?: string;
+}
+
+export interface MarketingPaymentEvent extends MarketingLifecycleEvent {
+  currency: string;
+  event: 'new_subscription' | 'topup_success';
+  transaction_id: string;
+  value: number;
 }
 
 export type ButtonActionType =
@@ -11,9 +60,58 @@ export type ButtonActionType =
   | 'auth-form';
 
 export const gtmPush = (event: GTMEvent) => {
-  if (typeof window !== 'undefined' && window.dataLayer) {
+  if (typeof window !== 'undefined') {
+    window.dataLayer = window.dataLayer || [];
     window.dataLayer.push(event);
   }
+};
+
+export const trackMarketingLifecycleEvent = (
+  event: MarketingLifecycleEvent | MarketingPaymentEvent,
+) => {
+  if (!event.event_id.trim()) {
+    throw new Error('Marketing lifecycle events require an event ID.');
+  }
+  if (Number.isNaN(Date.parse(event.occurred_at))) {
+    throw new Error('Marketing lifecycle events require an ISO timestamp.');
+  }
+  if ([event.gclid, event.gbraid, event.wbraid].filter(Boolean).length > 1) {
+    throw new Error('Marketing lifecycle events accept one Google click ID.');
+  }
+  if (event.hashed_user_data) {
+    const identifiers = Object.values(event.hashed_user_data);
+    if (
+      !event.ad_user_data_consent ||
+      identifiers.length === 0 ||
+      identifiers.some((value) => !/^[a-f0-9]{64}$/.test(value))
+    ) {
+      throw new Error('Hashed user data requires consent and SHA-256 values.');
+    }
+  }
+  if ('transaction_id' in event) {
+    const { currency, transaction_id: transactionId, value } = event;
+    if (typeof currency !== 'string' || !/^[A-Z]{3}$/.test(currency)) {
+      throw new Error('Marketing payment currency must use ISO 4217 format.');
+    }
+    if (
+      typeof transactionId !== 'string' ||
+      !transactionId.trim() ||
+      typeof value !== 'number' ||
+      !Number.isFinite(value) ||
+      value < 0
+    ) {
+      throw new Error(
+        'Marketing payment events require a transaction and value.',
+      );
+    }
+  }
+  gtmPush({
+    ...event,
+    first_touch_json: event.first_touch
+      ? JSON.stringify(event.first_touch)
+      : '',
+    last_touch_json: event.last_touch ? JSON.stringify(event.last_touch) : '',
+  });
 };
 
 export const trackPageView = (
@@ -36,7 +134,7 @@ export const trackButtonClick = (
   buttonLocation: string,
   actionType: ButtonActionType,
   actionTarget: string,
-  additionalData?: Record<string, any>,
+  additionalData?: Record<string, unknown>,
 ) => {
   gtmPush({
     context,
@@ -113,7 +211,7 @@ export const trackCustomEvent = (
   context: string,
 
   eventName: string,
-  eventData: Record<string, any>,
+  eventData: Record<string, unknown>,
 ) => {
   gtmPush({
     context,

--- a/new-components/AuthForm/AuthFormProvider.tsx
+++ b/new-components/AuthForm/AuthFormProvider.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from 'react';
 import { AuthFormProvider as BaseAuthFormProvider } from './AuthFormContext';
 import { EmailVerifyResponse } from './types';
 import { siteConfig } from '@/config/site';
+import { appendAttributionToUrl } from '@/lib/attribution';
 
 export function AuthFormProvider({ children }: { children: ReactNode }) {
   const handleVerifySuccess = (
@@ -23,7 +24,7 @@ export function AuthFormProvider({ children }: { children: ReactNode }) {
       });
     }
 
-    window.location.href = target.toString();
+    window.location.href = appendAttributionToUrl(target).toString();
   };
 
   return (

--- a/new-components/AuthForm/GoogleOneTap.tsx
+++ b/new-components/AuthForm/GoogleOneTap.tsx
@@ -3,6 +3,7 @@
 import Script from 'next/script';
 import { useCallback } from 'react';
 import { appDomain, siteConfig } from '@/config/site';
+import { appendAttributionToUrl } from '@/lib/attribution';
 
 type GoogleCredentialResponse = {
   credential?: string;
@@ -36,7 +37,7 @@ function buildOneTapRedirectUrl(data: { token: string; needInit?: boolean }) {
     target.searchParams.append('workspaceName', 'My Workspace');
   }
 
-  return target.toString();
+  return appendAttributionToUrl(target).toString();
 }
 
 declare global {

--- a/new-components/AuthForm/SelectMethodStep.tsx
+++ b/new-components/AuthForm/SelectMethodStep.tsx
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import { useAuthForm } from './AuthFormContext';
 import { useCountdown } from './hooks';
 import { SealosLogo, GoogleIcon, GithubIcon } from './components';
+import { appendAttributionToUrl } from '@/lib/attribution';
 
 export function SelectMethodStep() {
   const {
@@ -68,7 +69,7 @@ export function SelectMethodStep() {
       });
     }
     setOpen(false);
-    window.location.href = targetUrl.toString();
+    window.location.href = appendAttributionToUrl(targetUrl).toString();
   };
 
   return (

--- a/types/gtm.d.ts
+++ b/types/gtm.d.ts
@@ -1,6 +1,6 @@
 declare global {
   interface Window {
-    dataLayer: Array<Record<string, any>>;
+    dataLayer: Array<Record<string, unknown> | IArguments | unknown[]>;
   }
 }
 


### PR DESCRIPTION
## Summary

This PR adds the site-side measurement foundation for the Sealos Google Ads full-funnel rebuild.

- Initializes Consent Mode defaults before Google Tag Manager runs.
- Loads GTM at the first interactive lifecycle point.
- Persists `gclid`, `gbraid`, and `wbraid` through `sea_attr` and auth redirects.
- Adds typed lifecycle and payment event validation for the Ads contract.
- Carries first-touch and last-touch attribution into the GTM data layer.

## Scope

The PR contains the 11 site measurement files required for the new Search activation campaign contract. Existing comparison-page, navigation, App Store, and deployment-entry changes remain outside this PR and stay in the worktree for their own review.

Campaign creation, conversion-action edits, server-side uploads, Customer Match source preparation, and production GTM publishing remain operational follow-up gates. Existing PMax campaigns remain paused while those gates are completed.

## Verification

- `node --test lib/attribution.test.mts`: 4/4 passed.
- `npm run lint`: passed (`tsc --noEmit`).
- `npm run build`: passed; 6,179 static pages generated.
- AI FAQ route parity verification: 2,000 source/index/sitemap/route records, HTTP 200 for all 2,000 routes, 2 invalid-target checks accepted, 0 identity findings.
- `git diff --check upstream/main...HEAD`: passed.

## Measurement Contract

The implementation prepares the shared event shape for `build_started`, `deploy_success`, `running_24h`, `new_subscription`, and `topup_success`, including user, workspace, deployment, timestamp, first-touch, last-touch, and click-ID fields. Payment events require a unique `transaction_id`, ISO 4217 `currency`, and decimal major-unit `value`.

## Rollout Gates

Before enabling paid traffic, validate the container in GTM Preview and Tag Assistant, run Google Ads diagnostics, validate offline-import payloads, and verify duplicate `transaction_id` submissions deduplicate. Move to the full budget after measured registration attribution reaches 90% and the independent production checks pass.

Monitor activation rate from attributed registrations, payer CAC, 30-day and 90-day revenue, and weekly search-term quality. Keep the campaign and conversion-action changes in the Google Ads UI until those measurements are available.

## TDD Audit

| Test commit | Impl commit | gate_status |
|---|---|---|
| - | `6e88886` feat(analytics): add consent-safe Google Ads attribution | skill |

The implementation commit carries the required `gate_status: skill` line. Git 2.50's native trailer parser treats underscore keys as non-standard, so the PR audit table preserves the declared gate value explicitly.

gate_status: skill=1, fallback=0, exempt=0, missing=0
