### PR TITLE
fix: redirect www.sealos.io to canonical host

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,6 @@
 # Middleware + Nginx behavior migrated to Cloudflare Pages redirects.
 
+https://www.sealos.io/* https://sealos.io/:splat 301
 # Domain/language routing
 https://sealos.io/zh-cn https://sealos.run/zh-cn 302
 https://sealos.io/zh-cn/ https://sealos.run/zh-cn/ 302


### PR DESCRIPTION
Add a 301 redirect in public/_redirects so all www.sealos.io paths resolve to sealos.io with the same path.