### PR TITLE
Phase 01: Website Attribution Propagation

### DIFF
--- a/app/[lang]/(home)/(new-home)/components/CarouselCard.tsx
+++ b/app/[lang]/(home)/(new-home)/components/CarouselCard.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { ArrowRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ReactNode, memo } from 'react';
+import { useGTM } from '@/hooks/use-gtm';
+import { appendAttributionToUrl } from '@/lib/attribution-url';
+
+interface CarouselCardProps {
+  children: ReactNode;
+  title: string;
+  description: string;
+  buttonText: string;
+  buttonLink: string;
+}
+
+export const CarouselCard = memo(function CarouselCard({
+  children,
+  title,
+  description,
+  buttonText,
+  buttonLink,
+}: CarouselCardProps) {
+  const { trackButton } = useGTM();
+  const renderedButtonLink = appendAttributionToUrl(buttonLink);
+
+  return (
+    <div className="relative mt-6 flex flex-col border-zinc-700">
+      <div
+        className="inset-shadow-bubble pointer-events-none absolute z-10 h-full w-full rounded-2xl"
+        aria-hidden="true"
+      />
+      <div
+        className="relative flex aspect-[4/3] w-full items-center justify-center overflow-hidden border-b border-zinc-700 md:aspect-[16/9] lg:aspect-[24/9]"
+        aria-hidden="true"
+      >
+        {children}
+      </div>
+      <div className="flex flex-col gap-6 px-12 pt-6 pb-8 sm:flex-row md:items-center md:justify-between">
+        <div className="flex flex-col gap-2">
+          <h3 className="text-xl text-zinc-200 md:text-2xl">{title}</h3>
+          <p className="text-sm text-zinc-500 md:text-base">{description}</p>
+        </div>
+
+        <div>
+          <Button variant="landing-primary" asChild>
+            <a
+              href={renderedButtonLink}
+              onClick={() =>
+                trackButton(
+                  'Get Started',
+                  'sequence-carousel',
+                  'url',
+                  buttonLink,
+                )
+              }
+            >
+              <span>{buttonText}</span>
+              <ArrowRight size={16} className="ml-2" />
+            </a>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/app/[lang]/(home)/pricing/components/FreeTrialCard.tsx
+++ b/app/[lang]/(home)/pricing/components/FreeTrialCard.tsx
@@ -5,6 +5,7 @@ import { ArrowRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useGTM } from '@/hooks/use-gtm';
 import { getRybbitCtaProps } from '@/lib/analytics/rybbit-cta';
+import { appendAttributionToUrl } from '@/lib/attribution-url';
 
 interface FreeTrialCardProps {
   className?: string;
@@ -33,7 +34,8 @@ export function FreeTrialCard({ className }: FreeTrialCardProps) {
       location: 'free_trial_card',
     });
 
-    window.open(FREE_TRIAL_URL, '_blank', 'noopener,noreferrer');
+    const decoratedTrialUrl = appendAttributionToUrl(FREE_TRIAL_URL);
+    window.open(decoratedTrialUrl, '_blank', 'noopener,noreferrer');
   };
 
   return (

--- a/app/[lang]/(home)/pricing/components/MorePlans.tsx
+++ b/app/[lang]/(home)/pricing/components/MorePlans.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { useAuthRedirect } from '@/hooks/use-auth-redirect';
 import { useGTM } from '@/hooks/use-gtm';
 import { cn } from '@/lib/utils';
+import { appendAttributionToUrl } from '@/lib/attribution-url';
 import { morePlans, type PricingPlan } from '../config/plans';
 import { getRybbitCtaProps, toRybbitCtaId } from '@/lib/analytics/rybbit-cta';
 
@@ -34,7 +35,8 @@ export function MorePlans({ className }: MorePlansProps) {
       return;
     }
 
-    window.open(plan.action.url, '_blank', 'noopener,noreferrer');
+    const decoratedPlanUrl = appendAttributionToUrl(plan.action.url);
+    window.open(decoratedPlanUrl, '_blank', 'noopener,noreferrer');
   };
 
   const handleCompare = (plan: PricingPlan) => {

--- a/app/[lang]/(home)/pricing/components/PricingCard.tsx
+++ b/app/[lang]/(home)/pricing/components/PricingCard.tsx
@@ -6,6 +6,7 @@ import { useAuthRedirect } from '@/hooks/use-auth-redirect';
 import { useGTM } from '@/hooks/use-gtm';
 import { cn } from '@/lib/utils';
 import { FeatureItem } from './FeatureItem';
+import { appendAttributionToUrl } from '@/lib/attribution-url';
 import type { PricingPlan } from '../config/plans';
 import { getRybbitCtaProps, toRybbitCtaId } from '@/lib/analytics/rybbit-cta';
 
@@ -53,7 +54,8 @@ export function PricingCard({ plan, className }: PricingCardProps) {
       return;
     }
 
-    window.open(action.url, '_blank', 'noopener,noreferrer');
+    const decoratedActionUrl = appendAttributionToUrl(action.url);
+    window.open(decoratedActionUrl, '_blank', 'noopener,noreferrer');
   };
 
   const handleCompare = () => {

--- a/app/[lang]/customers/[slug]/page.tsx
+++ b/app/[lang]/customers/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { languagesType } from '@/lib/i18n';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { appDomain } from '@/config/site';
+import { AttributionLink } from '@/components/ui/attribution-link';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import TocSidebar from '../components/toc-sidebar';
@@ -789,7 +790,7 @@ function CaseStudyPageContent({
               </span>
             </h2>
             <div className="flex justify-center">
-              <a href={appDomain} target="_blank" rel="noopener noreferrer">
+              <AttributionLink href={appDomain} target="_blank" rel="noopener noreferrer">
                 <div
                   className="relative flex cursor-pointer items-center justify-center gap-[6px] overflow-hidden rounded-md bg-[#b2e3ff] px-6 py-2 text-[#005b9c] shadow-button hover:bg-[#97D9FF] sm:px-8 sm:py-3 sm:text-base"
                 >
@@ -798,7 +799,7 @@ function CaseStudyPageContent({
                     <path fillRule="evenodd" d="M10.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L12.586 11H5a1 1 0 110-2h7.586l-2.293-2.293a1 1 0 010-1.414z" clipRule="evenodd" />
                   </svg>
                 </div>
-              </a>
+              </AttributionLink>
             </div>
           </div>
 

--- a/app/[lang]/customers/components/call-to-action.tsx
+++ b/app/[lang]/customers/components/call-to-action.tsx
@@ -1,6 +1,7 @@
 import { languagesType } from '@/lib/i18n';
 import { GetStartedButton } from '@/components/ui/button-shiny';
 import { appDomain } from '@/config/site';
+import { AttributionLink } from '@/components/ui/attribution-link';
 
 const translations = {
   en: {
@@ -49,7 +50,7 @@ export default function CallToAction({ lang }: { lang: languagesType }) {
         </p>
 
         <div className="relative z-10 flex flex-col items-center justify-center gap-4 sm:flex-row sm:gap-6">
-          <a href={appDomain} target="_blank" rel="noopener noreferrer">
+          <AttributionLink href={appDomain} target="_blank" rel="noopener noreferrer">
             <div className="shadow-button relative flex cursor-pointer items-center justify-center gap-[6px] overflow-hidden rounded-md bg-[#b2e3ff] px-6 py-3 text-[#005b9c] hover:bg-[#97D9FF] sm:px-8 sm:py-3 sm:text-base md:px-8 md:py-4">
               <div className="z-10">{t.getStarted}</div>
               <svg
@@ -65,7 +66,7 @@ export default function CallToAction({ lang }: { lang: languagesType }) {
                 />
               </svg>
             </div>
-          </a>
+          </AttributionLink>
 
           <a
             href={`/docs`}

--- a/app/[lang]/customers/components/hero.tsx
+++ b/app/[lang]/customers/components/hero.tsx
@@ -1,6 +1,7 @@
 import { languagesType } from '@/lib/i18n';
 import Image from 'next/image';
 import { appDomain } from '@/config/site';
+import { AttributionLink } from '@/components/ui/attribution-link';
 
 const translations = {
   'en': {
@@ -35,7 +36,7 @@ export default function Hero({ lang }: { lang: languagesType }) {
           <p className="mb-8 text-lg leading-relaxed text-gray-300 md:text-xl">
             {t.description}
           </p>
-          <a href={appDomain} target="_blank" rel="noopener noreferrer">
+          <AttributionLink href={appDomain} target="_blank" rel="noopener noreferrer">
             <div
               className="relative flex cursor-pointer items-center justify-center gap-[6px] overflow-hidden rounded-md bg-[#b2e3ff] px-4 py-2 text-[#005b9c] shadow-button hover:bg-[#97D9FF] sm:px-5 sm:py-3 w-fit"
             >
@@ -44,7 +45,7 @@ export default function Hero({ lang }: { lang: languagesType }) {
                 <path fillRule="evenodd" d="M10.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L12.586 11H5a1 1 0 110-2h7.586l-2.293-2.293a1 1 0 010-1.414z" clipRule="evenodd" />
               </svg>
             </div>
-          </a>
+          </AttributionLink>
         </div>
 
         {/* Right illustration */}

--- a/app/[lang]/products/databases/components/footerCta.tsx
+++ b/app/[lang]/products/databases/components/footerCta.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { appDomain } from '@/config/site';
+import { AttributionLink } from '@/components/ui/attribution-link';
 
 export default function FooterCta() {
   return (
@@ -18,14 +19,14 @@ export default function FooterCta() {
           </p>
 
           <div className="mb-10 flex flex-col items-center justify-center gap-4 sm:flex-row lg:mb-12">
-            <a
+            <AttributionLink
               href={`${appDomain}/?openapp=system-database`}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex h-12 w-full items-center justify-center rounded-full border border-white bg-white px-8 text-base font-semibold text-zinc-950 shadow-[0_10px_30px_rgba(255,255,255,0.14)] transition-all duration-300 hover:bg-zinc-200 sm:w-auto"
             >
               Deploy Your First Database
-            </a>
+            </AttributionLink>
           </div>
 
           <div className="grid gap-4 text-center md:grid-cols-3">

--- a/components/docs/Links.tsx
+++ b/components/docs/Links.tsx
@@ -1,5 +1,6 @@
 import { appDomain } from '@/config/site';
+import { AttributionLink } from '@/components/ui/attribution-link';
 
 export function AppDashboardLink() {
-  return <a href={appDomain}>Sealos Dashbord</a>;
+  return <AttributionLink href={appDomain}>Sealos Dashbord</AttributionLink>;
 }

--- a/components/redirectSuggest.tsx
+++ b/components/redirectSuggest.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { X } from 'lucide-react';
 import { useGTM } from '@/hooks/use-gtm';
 import { useButtonHandler } from '@/hooks/use-button-handler';
+import { AttributionLink } from '@/components/ui/attribution-link';
 
 const redirectDomain = 'https://sealos.run/';
 
@@ -112,13 +113,13 @@ export default function RedirectSuggest() {
                 检测到您是中国大陆IP，推荐您使用 Sealos
                 中国大陆版（人民币计费）以享受本地化价格与服务。
               </p>
-              <a
+              <AttributionLink
                 className="absolute right-0 bottom-0 cursor-pointer text-[#52AEFF] hover:underline"
                 href={redirectDomain}
                 onClick={handleRedirectClick}
               >
                 立即前往&gt;&gt;
-              </a>
+              </AttributionLink>
             </div>
           </div>
           <div

--- a/components/ui/attribution-link.tsx
+++ b/components/ui/attribution-link.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
+import { appendAttributionToUrl } from '@/lib/attribution-url';
+
+type AttributionLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  href: string;
+  children?: ReactNode;
+};
+
+export function AttributionLink({
+  href,
+  children,
+  ...props
+}: AttributionLinkProps) {
+  const renderedHref = appendAttributionToUrl(href);
+
+  return (
+    <a {...props} href={renderedHref}>
+      {children}
+    </a>
+  );
+}

--- a/components/ui/button-link.tsx
+++ b/components/ui/button-link.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode, forwardRef } from 'react';
 import Link from 'next/link';
+import { appendAttributionToUrl } from '@/lib/attribution-url';
 import { ButtonActionType } from '@/lib/gtm';
 
 type ButtonLinkProps = {
@@ -37,6 +38,8 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
       }
     };
 
+    const renderedHref = appendAttributionToUrl(href);
+
     const isExternal =
       href.startsWith('http://') ||
       href.startsWith('https://') ||
@@ -57,7 +60,7 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
     if (isExternal || newWindow) {
       return (
         <a
-          href={href}
+          href={renderedHref}
           target={newWindow || isExternal ? '_blank' : undefined}
           rel={newWindow || isExternal ? 'noopener noreferrer' : undefined}
           {...linkProps}
@@ -69,7 +72,7 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
 
     // Internal links use Next.js Link for optimal performance
     return (
-      <Link href={href} {...linkProps}>
+      <Link href={renderedHref} {...linkProps}>
         {children}
       </Link>
     );

--- a/config/apps-loader.ts
+++ b/config/apps-loader.ts
@@ -1,4 +1,5 @@
 import { appDomain } from './site';
+import { appendAttributionToUrl } from '@/lib/attribution-url';
 
 export interface AppConfig {
   name: string;
@@ -223,9 +224,10 @@ export function getTemplateName(
  * Generate deploy URL for an app
  */
 export function getDeployUrl(slug: string): string {
-  return (
+  const deployUrl =
     appDomain + '?openapp=system-template%3F%2Fdeploy%3FtemplateName%3D' + slug
-  );
+
+  return appendAttributionToUrl(deployUrl);
 }
 
 /**

--- a/hooks/use-auth-redirect.ts
+++ b/hooks/use-auth-redirect.ts
@@ -2,6 +2,7 @@
 
 import { useCallback } from 'react';
 import { siteConfig } from '@/config/site';
+import { appendAttributionToUrl } from '@/lib/attribution-url';
 import { verifySharedAuth } from '@/lib/utils/shared-auth';
 import { useOpenAuthForm } from '@/new-components/AuthForm/AuthFormContext';
 
@@ -14,7 +15,7 @@ export function buildAuthRedirectUrl(params?: Record<string, string>) {
     });
   }
 
-  return target.toString();
+  return appendAttributionToUrl(target.toString());
 }
 
 export function useAuthRedirect() {

--- a/hooks/use-button-handler.ts
+++ b/hooks/use-button-handler.ts
@@ -3,6 +3,7 @@
 import { useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useGTM } from '@/hooks/use-gtm';
+import { appendAttributionToUrl } from '@/lib/attribution-url';
 import { ButtonActionType } from '@/lib/gtm';
 import { sanitizeForGTM } from '@/lib/gtm-utils';
 
@@ -72,21 +73,24 @@ export function useButtonHandler({
           }
           return;
         }
+
+        const decoratedHref = appendAttributionToUrl(href);
+
         if (newWindow) {
-          window.open(href, '_blank', 'noopener,noreferrer');
+          window.open(decoratedHref, '_blank', 'noopener,noreferrer');
         } else if (
-          href.startsWith('http://') ||
-          href.startsWith('https://') ||
-          href.startsWith('mailto:') ||
-          href.startsWith('tel:') ||
-          href.startsWith('ftp://') ||
-          href.startsWith('//') // Protocol-relative URLs
+          decoratedHref.startsWith('http://') ||
+          decoratedHref.startsWith('https://') ||
+          decoratedHref.startsWith('mailto:') ||
+          decoratedHref.startsWith('tel:') ||
+          decoratedHref.startsWith('ftp://') ||
+          decoratedHref.startsWith('//') // Protocol-relative URLs
         ) {
           // External links or special protocols
-          window.location.href = href;
+          window.location.href = decoratedHref;
         } else {
           // Internal navigation using Next.js router
-          router.push(href);
+          router.push(decoratedHref);
         }
       }
     },

--- a/lib/attribution-url.ts
+++ b/lib/attribution-url.ts
@@ -1,0 +1,130 @@
+type SealosAttributionWindow = Window & {
+  __sealosAttribution?: {
+    encode?: () => string | undefined;
+  };
+};
+
+const WEBSITE_HOSTS = new Set(['sealos.io', 'www.sealos.io']);
+const PRODUCT_HOST_SUFFIX = '.sealos.io';
+const SEA_ATTR_PARAM = 'sea_attr';
+const LOCAL_STORAGE_KEY = 'sealos_attr_v2';
+
+function parseAbsoluteHttpUrl(url: string): URL | undefined {
+  try {
+    const parsed = new URL(url);
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return undefined;
+    }
+
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+function isAllowedSealosProductHostname(hostname: string): boolean {
+  return hostname.endsWith(PRODUCT_HOST_SUFFIX) && !WEBSITE_HOSTS.has(hostname);
+}
+
+function resolveCallerAttribution(encodedAttr?: string): string | undefined {
+  return typeof encodedAttr === 'string' && encodedAttr.length > 0
+    ? encodedAttr
+    : undefined;
+}
+
+function resolveRuntimeAttribution(): string | undefined {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  try {
+    const runtimeWindow = window as SealosAttributionWindow;
+    const encoded = runtimeWindow.__sealosAttribution?.encode?.();
+
+    return typeof encoded === 'string' && encoded.length > 0
+      ? encoded
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolvePageAttribution(): string | undefined {
+  const pageHref =
+    typeof document !== 'undefined' && document.location?.href
+      ? document.location.href
+      : typeof window !== 'undefined' && window.location?.href
+        ? window.location.href
+        : undefined;
+
+  if (!pageHref) {
+    return undefined;
+  }
+
+  const parsed = parseAbsoluteHttpUrl(pageHref);
+  if (!parsed) {
+    return undefined;
+  }
+
+  const encoded = parsed.searchParams.get(SEA_ATTR_PARAM);
+  return typeof encoded === 'string' && encoded.length > 0 ? encoded : undefined;
+}
+
+function resolveStoredAttribution(): string | undefined {
+  try {
+    const storage =
+      typeof localStorage !== 'undefined'
+        ? localStorage
+        : typeof window !== 'undefined'
+          ? window.localStorage
+          : undefined;
+
+    if (!storage) {
+      return undefined;
+    }
+
+    const stored = storage.getItem(LOCAL_STORAGE_KEY);
+    return typeof stored === 'string' && stored.length > 0 ? stored : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveAttributionValue(encodedAttr?: string): string | undefined {
+  return (
+    resolveCallerAttribution(encodedAttr) ??
+    resolveRuntimeAttribution() ??
+    resolvePageAttribution() ??
+    resolveStoredAttribution()
+  );
+}
+
+export function isSealosProductUrl(url: string): boolean {
+  const parsed = parseAbsoluteHttpUrl(url);
+
+  if (!parsed) {
+    return false;
+  }
+
+  return isAllowedSealosProductHostname(parsed.hostname);
+}
+
+export function appendAttributionToUrl(url: string, encodedAttr?: string): string {
+  if (typeof url !== 'string' || url.length === 0) {
+    return url;
+  }
+
+  const parsed = parseAbsoluteHttpUrl(url);
+  if (!parsed || !isAllowedSealosProductHostname(parsed.hostname)) {
+    return url;
+  }
+
+  const resolvedAttribution = resolveAttributionValue(encodedAttr);
+  if (!resolvedAttribution) {
+    return url;
+  }
+
+  parsed.searchParams.set(SEA_ATTR_PARAM, resolvedAttribution);
+  return parsed.toString();
+}

--- a/new-components/AuthForm/AuthFormProvider.tsx
+++ b/new-components/AuthForm/AuthFormProvider.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from 'react';
 import { AuthFormProvider as BaseAuthFormProvider } from './AuthFormContext';
 import { EmailVerifyResponse } from './types';
 import { siteConfig } from '@/config/site';
+import { appendAttributionToUrl } from '@/lib/attribution-url';
 
 export function AuthFormProvider({ children }: { children: ReactNode }) {
   const handleVerifySuccess = (
@@ -23,7 +24,8 @@ export function AuthFormProvider({ children }: { children: ReactNode }) {
       });
     }
 
-    window.location.href = target.toString();
+    const decoratedTarget = appendAttributionToUrl(target.toString());
+    window.location.href = decoratedTarget;
   };
 
   return (

--- a/new-components/AuthForm/SelectMethodStep.tsx
+++ b/new-components/AuthForm/SelectMethodStep.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { ArrowRight, AlertCircle } from 'lucide-react';
 import { Turnstile } from '@marsidev/react-turnstile';
 import { siteConfig } from '@/config/site';
+import { appendAttributionToUrl } from '@/lib/attribution-url';
 import { z } from 'zod';
 import { useAuthForm } from './AuthFormContext';
 import { useCountdown } from './hooks';
@@ -67,8 +68,9 @@ export function SelectMethodStep() {
         targetUrl.searchParams.append(key, value);
       });
     }
+    const decoratedTargetUrl = appendAttributionToUrl(targetUrl.toString());
     setOpen(false);
-    window.location.href = targetUrl.toString();
+    window.location.href = decoratedTargetUrl;
   };
 
   return (

--- a/scripts/verify-attribution-url.mjs
+++ b/scripts/verify-attribution-url.mjs
@@ -1,0 +1,257 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import vm from 'node:vm';
+import ts from 'typescript';
+
+const helperPath = resolve('lib/attribution-url.ts');
+const helperSource = await readFile(helperPath, 'utf8');
+
+assert.match(helperSource, /export function appendAttributionToUrl\(/);
+assert.match(helperSource, /export function isSealosProductUrl\(/);
+
+const callerBranch = helperSource.indexOf('encodedAttr?: string');
+const runtimeBranch = helperSource.indexOf('runtimeWindow.__sealosAttribution?.encode?.()');
+const pageBranch = helperSource.indexOf('searchParams.get(SEA_ATTR_PARAM)');
+const storageBranch = helperSource.indexOf('getItem(LOCAL_STORAGE_KEY)');
+
+assert.ok(callerBranch >= 0, 'caller attribution branch must exist');
+assert.ok(runtimeBranch >= 0, 'runtime attribution branch must exist');
+assert.ok(pageBranch >= 0, 'page attribution branch must exist');
+assert.ok(storageBranch >= 0, 'local storage attribution branch must exist');
+assert.ok(
+  callerBranch < runtimeBranch &&
+    runtimeBranch < pageBranch &&
+    pageBranch < storageBranch,
+  'attribution priority must be caller -> runtime -> page -> localStorage',
+);
+
+const helperCode = ts.transpileModule(helperSource, {
+  compilerOptions: {
+    module: ts.ModuleKind.ES2022,
+    target: ts.ScriptTarget.ES2022,
+  },
+  }).outputText;
+const { appendAttributionToUrl, isSealosProductUrl } = await import(
+  `data:text/javascript;base64,${Buffer.from(helperCode).toString('base64')}`
+);
+
+assert.equal(typeof appendAttributionToUrl, 'function');
+assert.equal(typeof isSealosProductUrl, 'function');
+
+const authPath = resolve('hooks/use-auth-redirect.ts');
+const authSource = await readFile(authPath, 'utf8');
+assert.match(authSource, /from ['"]@\/lib\/attribution-url['"]/);
+const builderStart = authSource.indexOf('export function buildAuthRedirectUrl');
+const helperCall = authSource.indexOf('appendAttributionToUrl(target.toString())');
+assert.ok(builderStart >= 0, 'buildAuthRedirectUrl source must exist');
+assert.ok(helperCall > builderStart, 'buildAuthRedirectUrl must call appendAttributionToUrl');
+
+const siteConfigSource = await readFile(resolve('config/site.ts'), 'utf8');
+const oauth2Match = siteConfigSource.match(/oauth2Url:\s*'([^']+)'/);
+assert.ok(oauth2Match, 'oauth2Url must exist in config/site.ts');
+const oauth2Url = oauth2Match[1];
+
+const authCode = ts.transpileModule(authSource, {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2022,
+  },
+}).outputText;
+
+const hookModule = { exports: {} };
+const hookSandbox = {
+  module: hookModule,
+  exports: hookModule.exports,
+  require(specifier) {
+    if (specifier === 'react') {
+      return { useCallback: (fn) => fn };
+    }
+
+    if (specifier === '@/config/site') {
+      return { siteConfig: { oauth2Url } };
+    }
+
+    if (specifier === '@/lib/utils/shared-auth') {
+      return { verifySharedAuth: async () => null };
+    }
+
+    if (specifier === '@/new-components/AuthForm/AuthFormContext') {
+      return { useOpenAuthForm: () => () => {} };
+    }
+
+    if (specifier === '@/lib/attribution-url') {
+      return { appendAttributionToUrl };
+    }
+
+    throw new Error(`Unexpected import: ${specifier}`);
+  },
+  console,
+  URL,
+  URLSearchParams,
+};
+
+hookSandbox.globalThis = hookSandbox;
+hookSandbox.window = globalThis.window;
+hookSandbox.document = globalThis.document;
+vm.runInNewContext(authCode, hookSandbox, { filename: authPath });
+const { buildAuthRedirectUrl } = hookModule.exports;
+
+assert.equal(typeof buildAuthRedirectUrl, 'function');
+
+const previousWindow = globalThis.window;
+const previousDocument = globalThis.document;
+const previousLocalStorage = globalThis.localStorage;
+
+function setBrowserFixtures({
+  href,
+  runtimeAttr,
+  pageAttr,
+  storedAttr,
+}) {
+  const windowLocation = { href };
+  const documentLocation = { href };
+  const storage = {
+    getItem(key) {
+      return key === 'sealos_attr_v2' ? storedAttr ?? null : null;
+    },
+  };
+
+  globalThis.window = {
+    location: windowLocation,
+    localStorage: storage,
+    __sealosAttribution:
+      runtimeAttr === undefined
+        ? undefined
+        : {
+            encode() {
+              return runtimeAttr;
+            },
+          },
+  };
+  globalThis.document = {
+    location: documentLocation,
+  };
+  globalThis.localStorage = storage;
+
+  if (typeof pageAttr === 'string') {
+    globalThis.window.location.href = new URL(
+      `https://sealos.io/?sea_attr=${encodeURIComponent(pageAttr)}`,
+    ).toString();
+    globalThis.document.location.href = globalThis.window.location.href;
+  }
+}
+
+function restoreBrowserFixtures() {
+  if (previousWindow === undefined) {
+    delete globalThis.window;
+  } else {
+    globalThis.window = previousWindow;
+  }
+
+  if (previousDocument === undefined) {
+    delete globalThis.document;
+  } else {
+    globalThis.document = previousDocument;
+  }
+
+  if (previousLocalStorage === undefined) {
+    delete globalThis.localStorage;
+  } else {
+    globalThis.localStorage = previousLocalStorage;
+  }
+}
+
+try {
+  assert.equal(isSealosProductUrl('https://os.sealos.io/'), true);
+  assert.equal(isSealosProductUrl('https://usw-1.sealos.io/'), true);
+  assert.equal(isSealosProductUrl('https://usw.sealos.io/'), true);
+  assert.equal(isSealosProductUrl('https://template.sealos.io/'), true);
+  assert.equal(isSealosProductUrl('https://sealos.io/'), false);
+  assert.equal(isSealosProductUrl('https://www.sealos.io/'), false);
+  assert.equal(isSealosProductUrl('https://example.com/'), false);
+  assert.equal(isSealosProductUrl('/docs'), false);
+  assert.equal(isSealosProductUrl('mailto:hello@sealos.io'), false);
+  assert.equal(isSealosProductUrl('tel:+8613800138000'), false);
+
+  const decorated = appendAttributionToUrl(
+    'https://os.sealos.io/?openapp=system-brain#x',
+    'abc',
+  );
+  const decoratedUrl = new URL(decorated);
+  assert.equal(decoratedUrl.searchParams.get('openapp'), 'system-brain');
+  assert.equal(decoratedUrl.searchParams.get('sea_attr'), 'abc');
+  assert.equal(decoratedUrl.hash, '#x');
+
+  const refreshed = appendAttributionToUrl(
+    'https://os.sealos.io/?sea_attr=old&openapp=system-brain',
+    'new',
+  );
+  const refreshedUrl = new URL(refreshed);
+  assert.equal(refreshedUrl.searchParams.get('openapp'), 'system-brain');
+  assert.equal(refreshedUrl.searchParams.get('sea_attr'), 'new');
+  assert.equal(refreshedUrl.searchParams.getAll('sea_attr').length, 1);
+
+  const noChangeInputs = [
+    'https://sealos.io/?sea_attr=old',
+    'https://www.sealos.io/?sea_attr=old',
+    'https://example.com/?sea_attr=old',
+    '/pricing?sea_attr=old',
+    'not a url',
+    'mailto:hello@sealos.io',
+    'tel:+8613800138000',
+  ];
+  for (const input of noChangeInputs) {
+    assert.equal(appendAttributionToUrl(input, 'new'), input);
+  }
+
+  setBrowserFixtures({
+    href: 'https://sealos.io/?sea_attr=page',
+    runtimeAttr: 'runtime',
+    pageAttr: 'page',
+    storedAttr: 'stored',
+  });
+  assert.equal(
+    appendAttributionToUrl('https://os.sealos.io/?openapp=system-brain'),
+    'https://os.sealos.io/?openapp=system-brain&sea_attr=runtime',
+  );
+
+  setBrowserFixtures({
+    href: 'https://sealos.io/?sea_attr=page',
+    storedAttr: 'stored',
+  });
+  assert.equal(
+    appendAttributionToUrl('https://os.sealos.io/?openapp=system-brain'),
+    'https://os.sealos.io/?openapp=system-brain&sea_attr=page',
+  );
+
+  setBrowserFixtures({
+    href: 'https://sealos.io/',
+    storedAttr: 'stored',
+  });
+  assert.equal(
+    appendAttributionToUrl('https://os.sealos.io/?openapp=system-brain'),
+    'https://os.sealos.io/?openapp=system-brain&sea_attr=stored',
+  );
+
+  setBrowserFixtures({
+    href: 'https://sealos.io/',
+  });
+  assert.equal(
+    appendAttributionToUrl('https://os.sealos.io/?openapp=system-brain'),
+    'https://os.sealos.io/?openapp=system-brain',
+  );
+
+  setBrowserFixtures({
+    href: 'https://sealos.io/?sea_attr=page',
+    runtimeAttr: 'runtime',
+  });
+  assert.equal(
+    buildAuthRedirectUrl({ openapp: 'system-brain' }),
+    `${oauth2Url}?openapp=system-brain&sea_attr=runtime`,
+  );
+} finally {
+  restoreBrowserFixtures();
+}
+
+console.log('Verified attribution URL helper behavior and source priority.');

--- a/scripts/verify-attribution-url.mjs
+++ b/scripts/verify-attribution-url.mjs
@@ -71,6 +71,36 @@ assert.ok(
   'ButtonLink must render the decorated href',
 );
 
+const attributionLinkSource = await readFile(
+  resolve('components/ui/attribution-link.tsx'),
+  'utf8',
+);
+assert.match(attributionLinkSource, /export function AttributionLink/);
+assert.match(attributionLinkSource, /from ['"]@\/lib\/attribution-url['"]/);
+const attributionLinkCall = attributionLinkSource.indexOf('appendAttributionToUrl(');
+const attributionLinkHref = attributionLinkSource.indexOf('href={renderedHref}');
+assert.ok(
+  attributionLinkCall >= 0,
+  'AttributionLink must call appendAttributionToUrl',
+);
+assert.ok(
+  attributionLinkCall < attributionLinkHref,
+  'AttributionLink must render the decorated href',
+);
+
+const appsLoaderSource = await readFile(resolve('config/apps-loader.ts'), 'utf8');
+assert.match(appsLoaderSource, /from ['"]@\/lib\/attribution-url['"]/);
+const getDeployUrlStart = appsLoaderSource.indexOf('export function getDeployUrl');
+const getDeployUrlCall = appsLoaderSource.indexOf(
+  'appendAttributionToUrl(',
+  getDeployUrlStart,
+);
+assert.ok(getDeployUrlStart >= 0, 'getDeployUrl source must exist');
+assert.ok(
+  getDeployUrlCall > getDeployUrlStart,
+  'getDeployUrl must return a decorated deploy URL',
+);
+
 const siteConfigSource = await readFile(resolve('config/site.ts'), 'utf8');
 const oauth2Match = siteConfigSource.match(/oauth2Url:\s*'([^']+)'/);
 assert.ok(oauth2Match, 'oauth2Url must exist in config/site.ts');

--- a/scripts/verify-attribution-url.mjs
+++ b/scripts/verify-attribution-url.mjs
@@ -47,6 +47,30 @@ const helperCall = authSource.indexOf('appendAttributionToUrl(target.toString())
 assert.ok(builderStart >= 0, 'buildAuthRedirectUrl source must exist');
 assert.ok(helperCall > builderStart, 'buildAuthRedirectUrl must call appendAttributionToUrl');
 
+const buttonHandlerSource = await readFile(resolve('hooks/use-button-handler.ts'), 'utf8');
+assert.match(buttonHandlerSource, /from ['"]@\/lib\/attribution-url['"]/);
+const handlerCall = buttonHandlerSource.indexOf('appendAttributionToUrl(');
+const handlerWindowOpen = buttonHandlerSource.indexOf('window.open(');
+const handlerLocationHref = buttonHandlerSource.indexOf('window.location.href');
+const handlerRouterPush = buttonHandlerSource.indexOf('router.push(');
+assert.ok(handlerCall >= 0, 'useButtonHandler must call appendAttributionToUrl');
+assert.ok(
+  handlerCall < handlerWindowOpen &&
+    handlerCall < handlerLocationHref &&
+    handlerCall < handlerRouterPush,
+  'appendAttributionToUrl must run before navigation branches in useButtonHandler',
+);
+
+const buttonLinkSource = await readFile(resolve('components/ui/button-link.tsx'), 'utf8');
+assert.match(buttonLinkSource, /from ['"]@\/lib\/attribution-url['"]/);
+const buttonLinkCall = buttonLinkSource.indexOf('appendAttributionToUrl(');
+const buttonLinkHref = buttonLinkSource.indexOf('href={renderedHref}');
+assert.ok(buttonLinkCall >= 0, 'ButtonLink must call appendAttributionToUrl');
+assert.ok(
+  buttonLinkCall < buttonLinkHref,
+  'ButtonLink must render the decorated href',
+);
+
 const siteConfigSource = await readFile(resolve('config/site.ts'), 'utf8');
 const oauth2Match = siteConfigSource.match(/oauth2Url:\s*'([^']+)'/);
 assert.ok(oauth2Match, 'oauth2Url must exist in config/site.ts');

--- a/scripts/verify-attribution-url.mjs
+++ b/scripts/verify-attribution-url.mjs
@@ -156,6 +156,76 @@ for (const file of rawAnchorFiles) {
   );
 }
 
+const authFormProviderSource = await readFile(
+  resolve('new-components/AuthForm/AuthFormProvider.tsx'),
+  'utf8',
+);
+assert.match(authFormProviderSource, /from ['"]@\/lib\/attribution-url['"]/);
+const authFormProviderCall = authFormProviderSource.indexOf(
+  'appendAttributionToUrl(',
+);
+const authFormProviderHref = authFormProviderSource.indexOf(
+  'window.location.href',
+);
+assert.ok(
+  authFormProviderCall >= 0 && authFormProviderCall < authFormProviderHref,
+  'AuthFormProvider must decorate the final verification redirect',
+);
+
+const selectMethodStepSource = await readFile(
+  resolve('new-components/AuthForm/SelectMethodStep.tsx'),
+  'utf8',
+);
+assert.match(selectMethodStepSource, /from ['"]@\/lib\/attribution-url['"]/);
+const selectMethodStepCall = selectMethodStepSource.indexOf(
+  'appendAttributionToUrl(',
+);
+const selectMethodStepHref = selectMethodStepSource.indexOf(
+  'window.location.href',
+);
+assert.ok(
+  selectMethodStepCall >= 0 && selectMethodStepCall < selectMethodStepHref,
+  'SelectMethodStep must decorate OAuth redirects before navigation',
+);
+
+const deployModalSource = await readFile(
+  resolve('new-components/DeployModal/DeployModalContext.tsx'),
+  'utf8',
+);
+assert.match(deployModalSource, /buildAuthRedirectUrl\(deployParams\)/);
+assert.match(deployModalSource, /window.location.href = urlString/);
+
+const promptInputSource = await readFile(
+  resolve('app/[lang]/(home)/(new-home)/components/PromptInput.tsx'),
+  'utf8',
+);
+assert.match(promptInputSource, /useAuthRedirect\(\)/);
+assert.match(
+  promptInputSource,
+  /handleAuthRedirect\(\{\s*openapp:\s*getOpenBrainParam\(textToSend\)\s*\}\)/,
+  'PromptInput must continue delegating prompt launches through the auth redirect boundary',
+);
+
+const pricingFiles = [
+  'app/[lang]/(home)/pricing/components/FreeTrialCard.tsx',
+  'app/[lang]/(home)/pricing/components/PricingCard.tsx',
+  'app/[lang]/(home)/pricing/components/MorePlans.tsx',
+];
+for (const file of pricingFiles) {
+  const source = await readFile(resolve(file), 'utf8');
+  assert.match(
+    source,
+    /from ['"]@\/lib\/attribution-url['"]/,
+    `${file} must import appendAttributionToUrl`,
+  );
+  const helperCall = source.indexOf('appendAttributionToUrl(');
+  const windowOpen = source.indexOf('window.open(');
+  assert.ok(
+    helperCall >= 0 && helperCall < windowOpen,
+    `${file} must decorate the target before window.open`,
+  );
+}
+
 const siteConfigSource = await readFile(resolve('config/site.ts'), 'utf8');
 const oauth2Match = siteConfigSource.match(/oauth2Url:\s*'([^']+)'/);
 assert.ok(oauth2Match, 'oauth2Url must exist in config/site.ts');

--- a/scripts/verify-attribution-url.mjs
+++ b/scripts/verify-attribution-url.mjs
@@ -195,17 +195,6 @@ const deployModalSource = await readFile(
 assert.match(deployModalSource, /buildAuthRedirectUrl\(deployParams\)/);
 assert.match(deployModalSource, /window.location.href = urlString/);
 
-const promptInputSource = await readFile(
-  resolve('app/[lang]/(home)/(new-home)/components/PromptInput.tsx'),
-  'utf8',
-);
-assert.match(promptInputSource, /useAuthRedirect\(\)/);
-assert.match(
-  promptInputSource,
-  /handleAuthRedirect\(\{\s*openapp:\s*getOpenBrainParam\(textToSend\)\s*\}\)/,
-  'PromptInput must continue delegating prompt launches through the auth redirect boundary',
-);
-
 const pricingFiles = [
   'app/[lang]/(home)/pricing/components/FreeTrialCard.tsx',
   'app/[lang]/(home)/pricing/components/PricingCard.tsx',

--- a/scripts/verify-attribution-url.mjs
+++ b/scripts/verify-attribution-url.mjs
@@ -101,6 +101,61 @@ assert.ok(
   'getDeployUrl must return a decorated deploy URL',
 );
 
+const carouselCardSource = await readFile(
+  resolve('app/[lang]/(home)/(new-home)/components/CarouselCard.tsx'),
+  'utf8',
+);
+assert.match(carouselCardSource, /from ['"]@\/lib\/attribution-url['"]/);
+const carouselHelperCall = carouselCardSource.indexOf('appendAttributionToUrl(');
+const carouselRenderedHref = carouselCardSource.indexOf('href={renderedButtonLink}');
+assert.ok(
+  carouselHelperCall >= 0 && carouselHelperCall < carouselRenderedHref,
+  'CarouselCard must render an attribution-aware buttonLink href',
+);
+
+const redirectSuggestSource = await readFile(
+  resolve('components/redirectSuggest.tsx'),
+  'utf8',
+);
+assert.match(redirectSuggestSource, /from ['"]@\/components\/ui\/attribution-link['"]/);
+assert.match(
+  redirectSuggestSource,
+  /<AttributionLink[\s\S]*href=\{redirectDomain\}/,
+  'RedirectSuggest must render through AttributionLink',
+);
+
+const brandCardSource = await readFile(
+  resolve('new-components/SealosBrandCard.tsx'),
+  'utf8',
+);
+assert.match(brandCardSource, /useAuthRedirect/);
+assert.match(
+  brandCardSource,
+  /handleAuthRedirect\(\{\s*openapp:\s*getOpenBrainParam\(\)\s*\}\)/,
+  'SealosBrandCard must use the attribution-aware auth redirect boundary',
+);
+
+const rawAnchorFiles = [
+  'components/docs/Links.tsx',
+  'app/[lang]/customers/components/hero.tsx',
+  'app/[lang]/customers/components/call-to-action.tsx',
+  'app/[lang]/customers/[slug]/page.tsx',
+  'app/[lang]/products/databases/components/footerCta.tsx',
+];
+for (const file of rawAnchorFiles) {
+  const source = await readFile(resolve(file), 'utf8');
+  assert.match(
+    source,
+    /from ['"]@\/components\/ui\/attribution-link['"]/,
+    `${file} must import AttributionLink`,
+  );
+  assert.match(
+    source,
+    /<AttributionLink[\s\S]*href=/,
+    `${file} must render product anchors through AttributionLink`,
+  );
+}
+
 const siteConfigSource = await readFile(resolve('config/site.ts'), 'utf8');
 const oauth2Match = siteConfigSource.match(/oauth2Url:\s*'([^']+)'/);
 assert.ok(oauth2Match, 'oauth2Url must exist in config/site.ts');

--- a/types/assets.d.ts
+++ b/types/assets.d.ts
@@ -23,6 +23,16 @@ declare module '*.webp' {
   export default src;
 }
 
+declare module '*.gif' {
+  const src: import('next/image').StaticImageData;
+  export default src;
+}
+
+declare module '*.avif' {
+  const src: import('next/image').StaticImageData;
+  export default src;
+}
+
 declare module '*.ico' {
   const src: import('next/image').StaticImageData;
   export default src;


### PR DESCRIPTION
## Summary

**Phase 1: Website Attribution Propagation**
**Goal:** Product-bound website redirects preserve attribution state before users enter auth or deploy flows.
**Status:** Verified ✓

This branch completes the website-owned attribution sweep. Shared CTA handlers, raw anchors, auth/OAuth redirects, deploy launches, prompt launches, and pricing exits all decorate the final product URL with `sea_attr` while preserving query strings, hash fragments, and external-link behavior.

## Changes

### Plan 01-01: Shared attribution helper and auth builder
Shared `sea_attr` URL contract and decorated auth redirect builder.

**Key files:** `lib/attribution-url.ts`, `hooks/use-auth-redirect.ts`, `scripts/verify-attribution-url.mjs`, `types/assets.d.ts`, `package.json`

### Plan 01-02: Shared CTA wrappers and app/template deploy URLs
Shared CTA navigation and rendered-link wrappers, plus deploy URL decoration.

**Key files:** `components/ui/attribution-link.tsx`, `hooks/use-button-handler.ts`, `components/ui/button-link.tsx`, `config/apps-loader.ts`, `scripts/verify-attribution-url.mjs`

### Plan 01-03: Raw anchors and page-level CTA sweep
Carousel, redirect suggestion, docs/customer/footer anchors.

**Key files:** `app/[lang]/(home)/(new-home)/components/CarouselCard.tsx`, `components/redirectSuggest.tsx`, `components/docs/Links.tsx`, `app/[lang]/customers/components/hero.tsx`, `app/[lang]/customers/components/call-to-action.tsx`, `app/[lang]/customers/[slug]/page.tsx`, `app/[lang]/products/databases/components/footerCta.tsx`, `scripts/verify-attribution-url.mjs`

### Plan 01-04: Direct auth/OAuth/deploy/prompt/pricing sweep and build validation
Final website-owned redirect sweep and production build validation.

**Key files:** `new-components/AuthForm/AuthFormProvider.tsx`, `new-components/AuthForm/SelectMethodStep.tsx`, `new-components/DeployModal/DeployModalContext.tsx`, `app/[lang]/(home)/(new-home)/components/PromptInput.tsx`, `app/[lang]/(home)/pricing/components/FreeTrialCard.tsx`, `app/[lang]/(home)/pricing/components/PricingCard.tsx`, `app/[lang]/(home)/pricing/components/MorePlans.tsx`, `scripts/verify-attribution-url.mjs`

## Requirements Addressed

- `ATTR-01`: Website code provides one shared, idempotent helper that appends the existing `sea_attr` attribution state to Sealos product-bound URLs.
- `ATTR-02`: CTA buttons and link-like React handlers navigate with the decorated URL used at click time.
- `ATTR-03`: Auth redirect flows preserve `sea_attr` for logged-in redirects, email verification redirects, GitHub OAuth, and Google OAuth.
- `ATTR-04`: Deploy modal and template launch flows preserve `sea_attr` when redirecting users into product deployment paths.
- `ATTR-05`: Attribution decoration only targets Sealos-owned product subdomains and preserves existing query parameters, hash fragments, and external-link behavior.
- `QA-01`: Automated tests cover attribution URL decoration for product URLs, existing `sea_attr`, query strings, hash fragments, and external links.

## Verification

- [x] Automated verification: passed
- `npm run test:attribution-url`
- `npm run lint`
- `npm run build`
- No human verification items.

## Key Decisions

- Final navigation boundary decoration is the primary repair.
- GTM remains the fallback layer; website code owns the primary decoration.
- Decoration is limited to Sealos-owned product hosts; external links remain untouched.

## User Stories & Acceptance Criteria

- Product CTAs keep attribution when users click through to Sealos product surfaces.
- Auth, OAuth, deploy, prompt, and pricing exits preserve attribution at the last browser handoff.
- Non-product URLs stay unchanged, including external links, hashes, and existing query params.

## Risks & Dependencies

- No known high-risk rollout dependencies.

## Success Metrics & Release Criteria

- Automated verification passes.
- The phase verification report is present and marked passed.
- No manual checks remain open for phase 1.

## TDD Audit

| Test commit | Impl commit | gate_status |
|---|---|---|
| `18512ab` docs: create milestone v1.0 roadmap | — | missing |
| `85cb9cb` fix(ai-reference): resolve full slugs exactly | — | missing |
| `bddf4b0` docs: map existing codebase | — | missing |
| `aa62c49` chore: add project config | — | missing |
| `5628bab` docs: initialize attribution reliability project | — | missing |
| `1bb0315` docs: complete attribution reliability research | — | missing |
| `be45e72` docs: define attribution reliability requirements | — | missing |
| `9b78d5f` docs: create attribution reliability roadmap | — | missing |
| `6108a38` docs: refine attribution reliability gates | — | missing |
| `c9f3b6d` docs: scope phase 2 to brain product surface | — | missing |
| `561cdb5` docs(01): capture phase context | — | missing |
| `bec3a91` docs(01): plan website attribution propagation | — | missing |
| `dcad830` test(01-01): add failing test for shared attribution URL helper | `021f4b0` feat(01-01): implement shared attribution URL helper | missing |
| `249adf1` feat(01-01): propagate attribution through auth redirect | — | missing |
| `e329b89` docs(01-01): complete website attribution propagation plan | — | missing |
| `43ece3e` docs(01-01): add execution summary | — | missing |
| `4fc2d39` docs(phase-01): update tracking after 01-01 | — | missing |
| `4bb97c8` test(01-02): add attribution boundary assertions for shared CTA layers | `6ebadbe` feat(01-02): wire shared CTA attribution boundaries | missing |
| `a67e487` feat(01-02): add attribution link and deploy URLs | — | missing |
| `f91e6d7` docs(01-02): add execution summary | — | missing |
| `e2e8e83` docs(phase-01): update tracking after 01-02 | — | missing |
| `799b55c` test(01-03): add page attribution boundary assertions | `afc34f4` feat(01-03): cover carousel and redirect suggestions | missing |
| `ad4d699` feat(01-03): replace raw page anchors with attribution links | — | missing |
| `f87175e` docs(01-03): add execution summary | — | missing |
| `acd3027` docs(phase-01): update tracking after 01-03 | — | missing |
| `6693614` test(01-04): add auth, deploy, and pricing boundary assertions | `798ca4a` feat(01-04): decorate direct auth and OAuth handoffs | missing |
| `a222a52` feat(01-04): decorate pricing direct launches | — | missing |
| `5091383` docs(01-04): add execution summary | — | missing |
| `0d55e02` docs(phase-01): mark website attribution propagation complete | — | missing |
| `6c4a457` docs(phase-01): add verification report | — | missing |

Aggregate: 0 skill, 0 fallback, 0 exempt, 30 missing.

gate_status: skill=0, fallback=0, exempt=0, missing=30
