### PR TITLE
Refine Sealos Skills landing page copy

### DIFF
--- a/app/[lang]/(home)/sealos-skills/bottom-sections.tsx
+++ b/app/[lang]/(home)/sealos-skills/bottom-sections.tsx
@@ -129,6 +129,7 @@ export function FinalCtaSection() {
           <CopyCommandButton
             value={CODEX_INSTALL_COMMAND}
             label={PAGE_COPY.final.primaryCta}
+            copiedLabel="Copied - paste in your terminal"
             showStatus
             tone="accent"
             className="min-w-[148px]"
@@ -155,6 +156,9 @@ export function FinalCtaSection() {
           </TrackedLink>
         </div>
         <div className="mt-8 flex flex-wrap justify-center gap-5 text-sm">
+          <span className="text-[#AAA4B4]">
+            {PAGE_COPY.final.trust}
+          </span>
           <a
             href={REPO_URL}
             target="_blank"

--- a/app/[lang]/(home)/sealos-skills/components.tsx
+++ b/app/[lang]/(home)/sealos-skills/components.tsx
@@ -2,6 +2,8 @@ import {
   AgentDirectorySection,
   CapabilitiesSection,
   HeroSection,
+  ProblemBridgeSection,
+  CloudValueSection,
   SupportMatrixSection,
 } from './top-sections';
 import {
@@ -15,10 +17,12 @@ export function SealosSkillsLanding() {
   return (
     <main className="-mt-24 min-w-0 overflow-x-clip bg-[#13111C] text-[#F5F2F8] selection:bg-[#4CAFE1] selection:text-[#0D1720]">
       <HeroSection />
+      <ProblemBridgeSection />
+      <WorkflowSection />
+      <CapabilitiesSection />
+      <CloudValueSection />
       <AgentDirectorySection />
       <SupportMatrixSection />
-      <CapabilitiesSection />
-      <WorkflowSection />
       <InstallSection />
       <SetupFaqSection />
       <FinalCtaSection />

--- a/app/[lang]/(home)/sealos-skills/content.ts
+++ b/app/[lang]/(home)/sealos-skills/content.ts
@@ -27,50 +27,63 @@ export const PAGE_COPY = {
     eyebrow: 'SEALOS SKILLS',
     title: 'Your agent writes the code. Sealos ships it.',
     description:
-      'One open-source skill pack for deploying apps, connecting data, and verifying cloud changes from the agent you already use.',
+      'Give the AI coding agent you already use a verified path from repo to running app on Sealos Cloud. Sealos Skills prepares the runtime, connects databases and S3, deploys, and returns evidence you can review.',
     commandLabel: 'INSTALL FOR CODEX',
-    primaryCta: 'Install in Codex',
-    secondaryCta: 'Browse the source',
+    primaryCta: 'Copy Codex install',
+    secondaryCta: 'View on GitHub',
+    trustBar:
+      'Verified Codex plugin · 8 open-source skills · Reviewable .sealos/ evidence · MIT licensed',
     invocation: `Then run ${DEPLOY_PROMPT}.`,
+  },
+  problem: {
+    title: 'Code generation ends where cloud work begins.',
+    description:
+      'Containers, credentials, databases, storage, rollout checks, and updates still need a reliable path. Sealos Skills gives your agent that path and keeps every important artifact visible.',
+  },
+  cloudValue: {
+    title: 'Sealos Cloud keeps the handoff visible.',
+    description:
+      'You get a Kubernetes-native runtime, managed data and storage, and reviewable execution evidence in one workspace.',
   },
   directory: {
     title: 'Bring the same cloud path to your favorite agent.',
     description:
-      'Choose a host, copy its install path, and keep Sealos deployment close to your code.',
+      'Start with the verified Codex plugin. Claude Code and Qoder add command support through plugins. Other hosts use bundle, context, direct-skill, or repository paths with host-specific invocation.',
   },
   support: {
     title: 'One skill pack. Clear host paths.',
     description:
-      'Every integration reaches the same eight skills through a host-specific install and invocation surface.',
+      'Support levels, install paths, and command surfaces all come from one typed host catalog.',
   },
   capabilities: {
     eyebrow: 'CLOUD CAPABILITIES',
-    title: 'What your agent can finish on Sealos Cloud',
+    title: 'Finish the cloud handoff from your coding agent.',
     description:
-      'The pack covers the handoffs between a repository and a running application.',
+      'Eight focused skills cover runtime preparation, managed data, deployment, inspection, and repeatable updates on Sealos Cloud.',
   },
   workflow: {
-    title: 'From prompt to evidence.',
+    title: 'From one prompt to a verified runtime.',
     description:
-      'Each workflow ends with concrete artifacts, live checks, and a result you can review.',
+      'The agent inspects first, prepares only what the project needs, deploys or updates the workload, and returns files and live checks you can review.',
   },
   install: {
-    title: 'Install once. Use the same workflow everywhere.',
+    title: 'Choose your host. Keep the Sealos workflow.',
     description:
-      'Start with a native plugin or import the same root skill pack into your preferred agent.',
+      'Keep one workflow across Codex, Claude Code, skills.sh, and the rest of the supported hosts.',
   },
   setup: {
     eyebrow: 'Before the first run',
-    title: 'Bring a project. Sealos Skills guides the cloud setup.',
+    title: 'Start with a repo. Preflight guides the rest.',
     description:
-      'Preflight identifies the account, workspace, registry, and local tools required by the selected workflow.',
+      'Sealos Skills checks login, workspace, registry, Docker, and kubectl, then guides setup for the path your project needs.',
   },
   final: {
-    title: 'Install the skill. Ship the runtime.',
+    title: 'Install the skill. Ship with evidence.',
     description:
-      'Give your coding agent a cloud path it can inspect, repeat, and update.',
-    primaryCta: 'Install in Codex',
+      'Deploy one repo and review the generated artifacts, live URL, rollout status, logs, and resource footprint before you call it done.',
+    primaryCta: 'Copy Codex install',
     secondaryCta: 'Browse install paths',
+    trust: 'MIT licensed. Inspect every instruction and generated artifact.',
   },
 } as const;
 
@@ -116,6 +129,9 @@ export type AgentTarget = {
   vendor: string;
   mode: InstallMode;
   icon: AgentIconKey;
+  supportLevel: string;
+  commandSupport: string;
+  supportNote: string;
   install: string;
   installSummary: string;
   installNote: string;
@@ -134,6 +150,9 @@ export const AGENT_TARGETS = [
     vendor: 'OpenAI',
     mode: 'Plugin',
     icon: 'openai',
+    supportLevel: 'Verified',
+    commandSupport: 'Native commands',
+    supportNote: 'Verified native plugin for Codex CLI and Codex App.',
     install: CODEX_INSTALL_COMMAND,
     installSummary: 'Marketplace + plugin',
     installNote: 'Native marketplace install for Codex CLI and Codex App.',
@@ -150,6 +169,9 @@ export const AGENT_TARGETS = [
     vendor: 'Anthropic',
     mode: 'Plugin',
     icon: 'claude',
+    supportLevel: 'Managed plugin',
+    commandSupport: 'Plugin commands',
+    supportNote: 'Managed plugin with /sealos command support.',
     install: CLAUDE_INSTALL_COMMAND,
     installSummary: 'Marketplace + plugin',
     installNote: 'Managed plugin install with the same eight root skills.',
@@ -166,9 +188,13 @@ export const AGENT_TARGETS = [
     vendor: 'Qoder',
     mode: 'Package import',
     icon: 'qoder',
+    supportLevel: 'Package import',
+    commandSupport: 'Plugin commands',
+    supportNote:
+      'Build the package, import dist/sealos-<version>.zip, then run /sealos.',
     install: 'python3 scripts/package-qoder-plugin.py',
     installSummary: 'Build + import ZIP',
-    installNote: 'Build the package, then import dist/sealos-1.2.0.zip.',
+    installNote: 'Build the package, then import dist/sealos-<version>.zip.',
     invocation: '/sealos',
     guideHref: `${REPO_URL}#test-in-qoder`,
     capabilities: CORE_CAPABILITIES,
@@ -182,6 +208,9 @@ export const AGENT_TARGETS = [
     vendor: 'Google',
     mode: 'Extension',
     icon: 'gemini',
+    supportLevel: 'Context-only',
+    commandSupport: 'Context guidance',
+    supportNote: 'Context-only extension. Ask the agent to use Sealos Skills.',
     install:
       'gemini extensions install https://github.com/labring/sealos-skills',
     installSummary: 'GitHub extension',
@@ -199,6 +228,9 @@ export const AGENT_TARGETS = [
     vendor: 'Qwen',
     mode: 'Extension',
     icon: 'qwen',
+    supportLevel: 'Context-only',
+    commandSupport: 'Context guidance',
+    supportNote: 'Context-only extension. Ask the agent to use Sealos Skills.',
     install: 'qwen extensions install https://github.com/labring/sealos-skills',
     installSummary: 'GitHub extension',
     installNote: 'Loads repository guidance through the Qwen extension.',
@@ -215,6 +247,9 @@ export const AGENT_TARGETS = [
     vendor: 'ClawHub',
     mode: 'Bundle',
     icon: 'bot',
+    supportLevel: 'Bundle',
+    commandSupport: 'Runtime commands',
+    supportNote: 'ClawHub bundle. Command behavior follows the active runtime.',
     install: 'clawhub install labring/sealos-skills',
     installSummary: 'ClawHub bundle',
     installNote: 'Installs the complete skill pack through ClawHub.',
@@ -231,6 +266,9 @@ export const AGENT_TARGETS = [
     vendor: 'CodeBuddy',
     mode: 'Plugin',
     icon: 'codebuddy',
+    supportLevel: 'Marketplace plugin',
+    commandSupport: 'Host commands',
+    supportNote: 'Marketplace plugin. Command behavior follows CodeBuddy.',
     install: '/plugin marketplace add labring/sealos-skills',
     installSummary: 'Marketplace plugin',
     installNote: 'Registers the repository with the CodeBuddy marketplace.',
@@ -247,6 +285,9 @@ export const AGENT_TARGETS = [
     vendor: 'Amp',
     mode: 'Repo import',
     icon: 'code',
+    supportLevel: 'Repository import',
+    commandSupport: 'Host commands',
+    supportNote: 'Repository import. Invocation follows the host.',
     install: `${REPO_URL}.git`,
     installSummary: 'Repository import',
     installNote: 'Import the root skills directory from GitHub.',
@@ -263,6 +304,9 @@ export const AGENT_TARGETS = [
     vendor: 'Kimi',
     mode: 'Repo import',
     icon: 'code',
+    supportLevel: 'Repository import',
+    commandSupport: 'Host commands',
+    supportNote: 'Repository import. Invocation follows the host.',
     install: `${REPO_URL}.git`,
     installSummary: 'Repository import',
     installNote: 'Import the root skills directory from GitHub.',
@@ -279,6 +323,10 @@ export const AGENT_TARGETS = [
     vendor: 'Skills ecosystem',
     mode: 'Skill pack',
     icon: 'terminal',
+    supportLevel: 'Skill pack',
+    commandSupport: 'Direct deploy/database/S3 commands',
+    supportNote:
+      'Direct entries for deploy, database, and S3. Canvas uses verified deployment state through a plugin entry point.',
     install: SKILLS_SH_INSTALL_COMMAND,
     installSummary: 'Direct skill pack',
     installNote: 'Installs the root skills for compatible coding agents.',
@@ -357,10 +405,10 @@ export const SKILL_CATALOG = [
   {
     id: 'sealos-deploy',
     name: 'sealos-deploy',
-    title: 'Deploy a verified app',
+    title: 'Deploy and verify a live app',
     description:
-      'Inspect a repo, prepare its runtime, deploy it to Sealos Cloud, and verify the live workload.',
-    output: 'Verified application URL and workload status',
+      'Inspect the repo, prepare the runtime, deploy to Sealos Cloud, and verify the live URL, rollout, logs, and footprint.',
+    output: 'Verified URL, rollout, logs, and footprint',
     icon: 'rocket',
     span: 'wide',
     surface: 'accent',
@@ -368,10 +416,10 @@ export const SKILL_CATALOG = [
   {
     id: 'sealos-database',
     name: 'sealos-database',
-    title: 'Connect managed databases',
+    title: 'Connect a managed database',
     description:
-      'Create or connect Postgres, MySQL, MongoDB, or Redis and verify the application path.',
-    output: 'Connected data service and tested environment key',
+      'Create or connect Postgres, MySQL, MongoDB, or Redis, wire the required env key, and test the app path.',
+    output: 'Connected data service and validated env key',
     icon: 'database',
     span: 'standard',
     surface: 'panel',
@@ -379,9 +427,9 @@ export const SKILL_CATALOG = [
   {
     id: 'sealos-s3',
     name: 'sealos-s3',
-    title: 'Provision private S3 storage',
+    title: 'Connect private S3-compatible storage',
     description:
-      'Create a private bucket, wire the required environment values, and test real object operations.',
+      'Create a private bucket, wire credentials, and test upload, list, download, and presigned URL behavior.',
     output: 'Working storage path with protected credentials',
     icon: 'storage',
     span: 'standard',
@@ -390,9 +438,9 @@ export const SKILL_CATALOG = [
   {
     id: 'sealos-canvas',
     name: 'sealos-canvas',
-    title: 'Inspect live resources',
+    title: 'Inspect a verified deployment',
     description:
-      'Read saved deployment state and open a local, read-only view of Sealos resources.',
+      'Read .sealos/state.json and open a read-only local view of the verified deployment.',
     output: 'Local canvas backed by live resource data',
     icon: 'canvas',
     span: 'standard',
@@ -401,9 +449,9 @@ export const SKILL_CATALOG = [
   {
     id: 'sealos-app-builder',
     name: 'sealos-app-builder',
-    title: 'Build a Sealos Desktop app',
+    title: 'Build with the Sealos Desktop SDK',
     description:
-      'Apply SDK-aware guidance and platform conventions to a Sealos Desktop application.',
+      'Apply SDK-aware integration patterns to a Sealos Desktop application.',
     output: 'Desktop app foundation with integration context',
     icon: 'blocks',
     span: 'standard',
@@ -412,9 +460,9 @@ export const SKILL_CATALOG = [
   {
     id: 'cloud-native-readiness',
     name: 'cloud-native-readiness',
-    title: 'Assess cloud readiness',
+    title: 'Find deployment blockers early',
     description:
-      'Review runtime, state, storage, configuration, and operational signals before deployment.',
+      'Score readiness from 0 to 12 and return the next actions before deployment.',
     output: 'Concrete readiness findings and next actions',
     icon: 'readiness',
     span: 'standard',
@@ -423,9 +471,9 @@ export const SKILL_CATALOG = [
   {
     id: 'dockerfile-skill',
     name: 'dockerfile-skill',
-    title: 'Generate a Dockerfile',
+    title: 'Generate and build-test a Dockerfile',
     description:
-      'Generate and validate a production-ready Dockerfile for the detected framework and runtime.',
+      'Produce and build-test a production-oriented Dockerfile for the detected stack.',
     output: 'Build-tested container definition',
     icon: 'container',
     span: 'standard',
@@ -434,9 +482,9 @@ export const SKILL_CATALOG = [
   {
     id: 'docker-to-sealos',
     name: 'docker-to-sealos',
-    title: 'Convert Compose to Sealos',
+    title: 'Turn Compose into a validated Sealos template',
     description:
-      'Convert Docker Compose services into reviewable Sealos templates with quality gates.',
+      'Convert Docker Compose services into a validated Sealos template with quality gates.',
     output: 'Validated Sealos deployment template',
     icon: 'compose',
     span: 'full',
@@ -560,29 +608,29 @@ export type FaqItem = { question: string; answer: string };
 
 export const FAQ_ITEMS = [
   {
-    question: 'What do I need before my first deploy?',
+    question: 'What do I need before the first run?',
     answer:
-      'Bring a compatible coding agent and a project. Deployment uses a Sealos Cloud account and container registry access. Database and S3 workflows also use an active Sealos workspace.',
+      'Bring a compatible coding agent and a project. Preflight checks the account, registry, workspace, Docker, and kubectl surface for the selected workflow.',
   },
   {
-    question: 'What does the Sealos plugin install?',
+    question: 'Will Sealos Skills change cloud resources automatically?',
     answer:
-      'One managed package installs all eight root skills: deploy, database, S3, Canvas, app builder, cloud-native readiness, Dockerfile generation, and Docker Compose conversion.',
-  },
-  {
-    question: 'Which coding agents can use Sealos Skills?',
-    answer:
-      'Codex and Claude Code use plugins. Qoder imports a package. OpenClaw uses a bundle. Gemini and Qwen use context extensions. Amp and Kimi import the repository.',
-  },
-  {
-    question: 'When are Docker and kubectl used?',
-    answer:
-      'Docker supports local image builds. kubectl supports deployment discovery, updates, rollout verification, and Canvas inspection. Preflight selects the tools required by each workflow.',
+      'Sensitive actions keep target confirmation in the loop and ask for confirmation before credential or access changes.',
   },
   {
     question: 'How are credentials handled?',
     answer:
-      'Sealos authentication, kubeconfig, database credentials, and S3 keys remain in protected local files or project environment files. Reports include resource references and verification evidence.',
+      'Credentials stay in protected local or project environment files. Chat output references them through paths and evidence.',
+  },
+  {
+    question: 'How does it verify a deployment?',
+    answer:
+      'Verification covers rollout, URL, logs, setup flow, and resource footprint.',
+  },
+  {
+    question: 'Can it update an existing deployment?',
+    answer:
+      'Yes. The agent reads verified state, confirms the target, patches the rollout, and records the result.',
   },
   {
     question: 'When can I use Canvas?',
@@ -590,8 +638,8 @@ export const FAQ_ITEMS = [
       'Canvas works after a deploy run creates .sealos/state.json. It reads the saved target, queries resources with read-only commands, and opens a temporary local view.',
   },
   {
-    question: 'Can Sealos Skills update an existing deployment?',
+    question: 'What does it cost?',
     answer:
-      'Yes. A later deploy run reads .sealos/state.json, confirms the target, rebuilds or reuses the image, patches the rollout, and records the result.',
+      'The skill pack is MIT licensed. Cloud usage follows workspace resources and region pricing.',
   },
 ] as const satisfies readonly FaqItem[];

--- a/app/[lang]/(home)/sealos-skills/copy-command.tsx
+++ b/app/[lang]/(home)/sealos-skills/copy-command.tsx
@@ -46,6 +46,7 @@ export function CopyCommandButton({
   className,
   iconClassName,
   label,
+  copiedLabel = 'Copied',
   showStatus = false,
   tone = 'secondary',
   tracking,
@@ -54,6 +55,7 @@ export function CopyCommandButton({
   className?: string;
   iconClassName?: string;
   label: string;
+  copiedLabel?: string;
   showStatus?: boolean;
   tone?: CopyButtonTone;
   tracking?: RybbitCtaTracking;
@@ -80,7 +82,7 @@ export function CopyCommandButton({
         : Copy;
   const visibleLabel =
     copyState === 'copied'
-      ? 'Copied'
+      ? copiedLabel
       : copyState === 'failed'
         ? 'Try again'
         : label;

--- a/app/[lang]/(home)/sealos-skills/interactive-sections.tsx
+++ b/app/[lang]/(home)/sealos-skills/interactive-sections.tsx
@@ -101,7 +101,7 @@ export function WorkflowTabs() {
             <code>{activeScenario.prompt}</code>
           </pre>
           <h3 className="mt-8 text-sm font-semibold text-[#F5F2F8]">
-            What the agent does
+            Three steps
           </h3>
           <ol className="mt-4 space-y-4">
             {activeScenario.action.map((action) => (
@@ -127,7 +127,7 @@ export function WorkflowTabs() {
               strokeWidth={1.7}
               aria-hidden="true"
             />
-            <h3 className="text-sm font-semibold">What you can review</h3>
+            <h3 className="text-sm font-semibold">Reviewable evidence</h3>
           </div>
           <div className="mt-5 border-t border-[#F5F2F8]/10">
             {activeScenario.evidence.map((evidence) => (
@@ -235,12 +235,15 @@ export function InstallTabs() {
               <p className="mt-5 font-mono text-sm text-[#4CAFE1]">
                 Invoke with {activeTarget.invocation}
               </p>
+              <p className="mt-2 text-xs leading-5 text-[#8F899B]">
+                {activeTarget.note}
+              </p>
             </div>
             <CopyCommandButton
               value={activeTarget.command}
               label={
                 activeTarget.id === 'codex'
-                  ? 'Install in Codex'
+                  ? 'Copy Codex install'
                   : 'Copy install'
               }
               showStatus
@@ -265,18 +268,21 @@ export function InstallTabs() {
                     <h3 className="text-sm font-semibold text-[#F5F2F8]">
                       {agent.name}
                     </h3>
-                    <span className="font-mono text-[11px] text-[#7F798A]">
-                      {agent.mode}
+                    <span className="rounded-sm border border-[#4CAFE1]/20 bg-[#4CAFE1]/10 px-2 py-1 font-mono text-[11px] text-[#BFE8F7]">
+                      {agent.supportLevel}
                     </span>
                   </div>
                   <code className="mt-2 block overflow-x-auto font-mono text-[11px] leading-5 whitespace-pre text-[#AAA4B4]">
                     {agent.install}
                   </code>
                   <p className="mt-2 text-xs leading-5 text-[#8F899B]">
-                    {agent.installNote}
+                    {agent.supportNote}
                   </p>
                   <p className="mt-2 font-mono text-xs leading-5 text-[#4CAFE1]">
                     Invoke: {agent.invocation}
+                  </p>
+                  <p className="mt-1 text-xs leading-5 text-[#7F798A]">
+                    Command surface: {agent.commandSupport}
                   </p>
                 </div>
                 <CopyCommandButton

--- a/app/[lang]/(home)/sealos-skills/page.tsx
+++ b/app/[lang]/(home)/sealos-skills/page.tsx
@@ -21,7 +21,7 @@ const SEALOS_SKILLS_URL = 'https://sealos.io/sealos-skills/';
 const SEALOS_SKILLS_IMAGE =
   'https://sealos.io/images/sealos-skills/codex-sealos.png';
 const SEO_DESCRIPTION =
-  'Install Sealos Skills in Codex, Claude Code, Qoder, Gemini, Qwen, and compatible AI coding agents. Deploy apps, connect databases and S3 storage, and verify cloud rollouts on Sealos.';
+  'Install Sealos Skills in Codex, Claude Code, Qoder, and other AI coding agents. Deploy apps, connect databases and S3, and verify rollouts on Sealos Cloud.';
 
 export function generateMetadata(): Metadata {
   return generatePageMetadata({

--- a/app/[lang]/(home)/sealos-skills/top-sections.tsx
+++ b/app/[lang]/(home)/sealos-skills/top-sections.tsx
@@ -15,7 +15,6 @@ import { CopyCommandButton } from './copy-command';
 import {
   AGENT_TARGETS,
   CODEX_INSTALL_COMMAND,
-  CORE_CAPABILITIES,
   PAGE_COPY,
   PROOF_ITEMS,
   REPO_URL,
@@ -64,6 +63,7 @@ export function HeroSection() {
               <CopyCommandButton
                 value={CODEX_INSTALL_COMMAND}
                 label={PAGE_COPY.hero.primaryCta}
+                copiedLabel="Copied - paste in your terminal"
                 showStatus
                 tone="accent"
                 className="min-w-[148px]"
@@ -84,6 +84,9 @@ export function HeroSection() {
                 {PAGE_COPY.hero.secondaryCta}
               </TrackedLink>
             </div>
+            <p className="mt-5 max-w-[62ch] font-mono text-xs leading-5 text-[#8F899B]">
+              {PAGE_COPY.hero.trustBar}
+            </p>
           </div>
 
           <div className="min-w-0 overflow-hidden rounded-lg border border-[#F5F2F8]/12 bg-[#0F0D17] shadow-[0_28px_80px_rgba(8,7,14,0.42)]">
@@ -116,6 +119,50 @@ export function HeroSection() {
   );
 }
 
+export function ProblemBridgeSection() {
+  return (
+    <SectionShell id="problem" className="py-16 sm:py-24">
+      <div className="grid gap-8 lg:grid-cols-[0.92fr_1.08fr] lg:items-start">
+        <SectionHeading
+          title={PAGE_COPY.problem.title}
+          description={PAGE_COPY.problem.description}
+        />
+        <div className="grid gap-3 sm:grid-cols-3">
+          {[
+            {
+              title: 'Containers and ports',
+              description:
+                'Runtime preparation, image choice, and service wiring still need attention.',
+            },
+            {
+              title: 'Credentials and data',
+              description:
+                'Databases and storage need a controlled setup path that survives handoff.',
+            },
+            {
+              title: 'Rollouts and updates',
+              description:
+                'Live checks, logs, and state records turn each deploy into a reviewable change.',
+            },
+          ].map((item) => (
+            <div
+              key={item.title}
+              className="rounded-lg border border-[#F5F2F8]/10 bg-[#191624] p-5"
+            >
+              <h3 className="text-sm font-semibold text-[#F5F2F8]">
+                {item.title}
+              </h3>
+              <p className="mt-2 text-sm leading-6 text-[#AAA4B4]">
+                {item.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </SectionShell>
+  );
+}
+
 export function AgentDirectorySection() {
   return (
     <SectionShell id="compatibility" className="py-16 sm:py-24">
@@ -143,14 +190,14 @@ export function AgentDirectorySection() {
           <article
             key={agent.id}
             className={cn(
-              'flex min-h-[336px] min-w-0 flex-col rounded-lg border border-[#F5F2F8]/10 bg-[#191624] p-5 transition duration-200 hover:-translate-y-0.5 hover:border-[#4CAFE1]/45 motion-reduce:transform-none motion-reduce:transition-none',
+              'flex min-h-[312px] min-w-0 flex-col rounded-lg border border-[#F5F2F8]/10 bg-[#191624] p-5 transition duration-200 hover:-translate-y-0.5 hover:border-[#4CAFE1]/45 motion-reduce:transform-none motion-reduce:transition-none',
               index >= 8 && 'lg:col-span-2',
             )}
           >
             <div className="flex items-start justify-between gap-4">
               <AgentMark icon={agent.icon} name={agent.name} />
-              <span className="rounded-sm border border-[#F5F2F8]/12 px-2 py-1 font-mono text-[11px] text-[#AAA4B4]">
-                {agent.mode}
+              <span className="rounded-sm border border-[#4CAFE1]/25 bg-[#4CAFE1]/10 px-2 py-1 font-mono text-[11px] text-[#BFE8F7]">
+                {agent.supportLevel}
               </span>
             </div>
             <p className="mt-5 text-xs text-[#7F798A]">{agent.vendor}</p>
@@ -158,7 +205,10 @@ export function AgentDirectorySection() {
               {agent.name}
             </h3>
             <p className="mt-3 min-h-[42px] text-sm leading-6 text-[#AAA4B4]">
-              {agent.installNote}
+              {agent.supportNote}
+            </p>
+            <p className="mt-2 font-mono text-xs leading-5 text-[#8F899B]">
+              Command surface: {agent.commandSupport}
             </p>
             <pre className="mt-4 min-h-[64px] min-w-0 overflow-x-auto rounded-md border border-[#F5F2F8]/10 bg-[#100E18] p-3 font-mono text-[11px] leading-5 whitespace-pre text-[#D8D2E0]">
               <code>{agent.install}</code>
@@ -166,21 +216,6 @@ export function AgentDirectorySection() {
             <p className="mt-3 min-h-[40px] font-mono text-xs leading-5 text-[#4CAFE1]">
               Invoke: {agent.invocation}
             </p>
-            <div className="mt-4 grid grid-cols-2 gap-x-3 gap-y-2">
-              {agent.capabilities.map((capability) => (
-                <span
-                  key={capability}
-                  className="flex items-center gap-2 text-xs text-[#9F99AA]"
-                >
-                  <Check
-                    className="size-3.5 text-[#4CAFE1]"
-                    strokeWidth={1.8}
-                    aria-hidden="true"
-                  />
-                  {capability}
-                </span>
-              ))}
-            </div>
             <div className="mt-auto grid grid-cols-2 gap-2 pt-5">
               <CopyCommandButton
                 value={agent.install}
@@ -226,7 +261,7 @@ export function SupportMatrixSection() {
         role="region"
         aria-label="Sealos Skills host support matrix"
       >
-        <table className="w-full min-w-[1080px] border-collapse text-left">
+        <table className="w-full min-w-[1240px] border-collapse text-left">
           <caption className="sr-only">
             Installation and capability support for Sealos Skills agent hosts
           </caption>
@@ -234,10 +269,12 @@ export function SupportMatrixSection() {
             <tr>
               {[
                 'Agent',
+                'Support level',
                 'Install mode',
                 'Install path',
                 'Invoke',
-                ...CORE_CAPABILITIES,
+                'Command surface',
+                'Skill source',
               ].map((column, index) => (
                 <th
                   key={column}
@@ -263,37 +300,30 @@ export function SupportMatrixSection() {
                   {agent.name}
                 </th>
                 <td className="border-b border-[#F5F2F8]/8 px-4 py-4 text-sm text-[#C3BDCC]">
+                  <span className="block font-semibold text-[#F5F2F8]">
+                    {agent.supportLevel}
+                  </span>
+                  <span className="mt-1 block text-xs text-[#7F798A]">
+                    {agent.supportNote}
+                  </span>
+                </td>
+                <td className="border-b border-[#F5F2F8]/8 px-4 py-4 text-sm text-[#C3BDCC]">
                   {agent.mode}
                 </td>
                 <td className="border-b border-[#F5F2F8]/8 px-4 py-4 text-sm text-[#AAA4B4]">
                   <code className="block max-w-[420px] text-xs leading-5 whitespace-pre-wrap text-[#D8D2E0]">
                     {agent.install}
                   </code>
-                  <span className="mt-2 block text-xs text-[#7F798A]">
-                    {agent.installSummary}
-                  </span>
-                  {agent.id === 'qoder' && (
-                    <span className="mt-1 block text-xs text-[#7F798A]">
-                      {agent.installNote}
-                    </span>
-                  )}
                 </td>
                 <td className="border-b border-[#F5F2F8]/8 px-4 py-4 font-mono text-xs text-[#4CAFE1]">
                   {agent.invocation}
                 </td>
-                {agent.capabilities.map((capability) => (
-                  <td
-                    key={capability}
-                    className="border-b border-[#F5F2F8]/8 px-4 py-4 text-center"
-                  >
-                    <Check
-                      className="mx-auto size-4 text-[#4CAFE1]"
-                      strokeWidth={1.8}
-                      aria-hidden="true"
-                    />
-                    <span className="sr-only">Available</span>
-                  </td>
-                ))}
+                <td className="border-b border-[#F5F2F8]/8 px-4 py-4 text-sm text-[#AAA4B4]">
+                  {agent.commandSupport}
+                </td>
+                <td className="border-b border-[#F5F2F8]/8 px-4 py-4 text-sm text-[#AAA4B4]">
+                  {agent.installSummary}
+                </td>
               </tr>
             ))}
           </tbody>
@@ -376,6 +406,48 @@ export function CapabilitiesSection() {
             </article>
           );
         })}
+      </div>
+    </SectionShell>
+  );
+}
+
+export function CloudValueSection() {
+  return (
+    <SectionShell className="py-16 sm:py-24">
+      <SectionHeading
+        title={PAGE_COPY.cloudValue.title}
+        description={PAGE_COPY.cloudValue.description}
+      />
+      <div className="mt-10 grid gap-3 md:grid-cols-3">
+        {[
+          {
+            title: 'Kubernetes-native runtime',
+            description:
+              'Sealos keeps the deploy target close to the cluster model your agent already reasons about.',
+          },
+          {
+            title: 'Managed data and storage',
+            description:
+              'Databases and S3 live in the same workspace as the app, so the handoff stays coherent.',
+          },
+          {
+            title: 'Reviewable execution evidence',
+            description:
+              'Generated artifacts, rollout status, logs, and resource state stay visible for review.',
+          },
+        ].map((item) => (
+          <div
+            key={item.title}
+            className="rounded-lg border border-[#F5F2F8]/10 bg-[#191624] p-5"
+          >
+            <h3 className="text-sm font-semibold text-[#F5F2F8]">
+              {item.title}
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-[#AAA4B4]">
+              {item.description}
+            </p>
+          </div>
+        ))}
       </div>
     </SectionShell>
   );

--- a/tests/sealos-skills-page.test.ts
+++ b/tests/sealos-skills-page.test.ts
@@ -41,6 +41,7 @@ test('Sealos Skills uses the official host install paths', () => {
   for (const command of commands) {
     assert.ok(contentSource.includes(command), `missing command: ${command}`);
   }
+  assert.ok(contentSource.includes('dist/sealos-<version>.zip'));
 
   for (const host of [
     'Codex',
@@ -65,6 +66,9 @@ test('Sealos Skills uses the official host install paths', () => {
     contentSource.indexOf('export type InstallTargetId'),
   );
   assert.equal([...agentsBlock.matchAll(/copyTrackingId:/g)].length, 10);
+  assert.equal([...agentsBlock.matchAll(/supportLevel:/g)].length, 10);
+  assert.equal([...agentsBlock.matchAll(/commandSupport:/g)].length, 10);
+  assert.equal([...agentsBlock.matchAll(/supportNote:/g)].length, 10);
   for (const mode of [
     'Plugin',
     'Package import',
@@ -117,14 +121,14 @@ test('Sealos Skills exposes the eight repository skills', () => {
   assert.deepEqual(
     [...skillsBlock.matchAll(/title: '([^']+)'/g)].map((match) => match[1]),
     [
-      'Deploy a verified app',
-      'Connect managed databases',
-      'Provision private S3 storage',
-      'Inspect live resources',
-      'Build a Sealos Desktop app',
-      'Assess cloud readiness',
-      'Generate a Dockerfile',
-      'Convert Compose to Sealos',
+      'Deploy and verify a live app',
+      'Connect a managed database',
+      'Connect private S3-compatible storage',
+      'Inspect a verified deployment',
+      'Build with the Sealos Desktop SDK',
+      'Find deployment blockers early',
+      'Generate and build-test a Dockerfile',
+      'Turn Compose into a validated Sealos template',
     ],
   );
 });
@@ -132,24 +136,28 @@ test('Sealos Skills exposes the eight repository skills', () => {
 test('Sealos Skills renders the approved conversion hierarchy and section order', () => {
   for (const copy of [
     'Your agent writes the code. Sealos ships it.',
-    'Install in Codex',
+    'Copy Codex install',
     'Bring the same cloud path to your favorite agent.',
     'One skill pack. Clear host paths.',
-    'What your agent can finish on Sealos Cloud',
-    'From prompt to evidence.',
-    'Install once. Use the same workflow everywhere.',
-    'Before the first run',
-    'Install the skill. Ship the runtime.',
+    'Code generation ends where cloud work begins.',
+    'From one prompt to a verified runtime.',
+    'Finish the cloud handoff from your coding agent.',
+    'Sealos Cloud keeps the handoff visible.',
+    'Choose your host. Keep the Sealos workflow.',
+    'Start with a repo. Preflight guides the rest.',
+    'Install the skill. Ship with evidence.',
   ]) {
     assert.ok(contentSource.includes(copy), `missing page copy: ${copy}`);
   }
 
   const orderedSections = [
     '<HeroSection />',
+    '<ProblemBridgeSection />',
+    '<WorkflowSection />',
+    '<CapabilitiesSection />',
+    '<CloudValueSection />',
     '<AgentDirectorySection />',
     '<SupportMatrixSection />',
-    '<CapabilitiesSection />',
-    '<WorkflowSection />',
     '<InstallSection />',
     '<SetupFaqSection />',
     '<FinalCtaSection />',
@@ -192,6 +200,7 @@ test('Sealos Skills keeps the Railway-inspired visual contract focused', () => {
   assert.ok(topSource.includes('Georgia, "Times New Roman", serif'));
   assert.ok(topSource.includes('text-[42px]'));
   assert.ok(topSource.includes('lg:text-[56px]'));
+  assert.ok(topSource.includes('Copied - paste in your terminal'));
   assert.equal(routeSource.includes('PageTopRays'), false);
   assert.equal(routeSource.includes('bg-gradient'), false);
   assert.equal(/[—–]/u.test(routeSource), false);
@@ -200,13 +209,12 @@ test('Sealos Skills keeps the Railway-inspired visual contract focused', () => {
 test('Sealos Skills matrix, workflows, and FAQ cover the public contract', () => {
   for (const column of [
     'Agent',
+    'Support level',
     'Install mode',
     'Install path',
     'Invoke',
-    'Deploy',
-    'Database',
-    'S3',
-    'Canvas',
+    'Command surface',
+    'Skill source',
   ]) {
     assert.ok(
       routeSource.includes(`'${column}'`),
@@ -217,6 +225,8 @@ test('Sealos Skills matrix, workflows, and FAQ cover the public contract', () =>
   for (const workflow of ['deploy', 'postgres', 's3', 'canvas']) {
     assert.ok(contentSource.includes(`id: '${workflow}'`));
   }
+
+  assert.equal(routeSource.includes('Available'), false);
 
   for (const prerequisite of [
     'Sealos Cloud account',
@@ -237,6 +247,11 @@ test('Sealos Skills metadata includes canonical routing and five schema types', 
   assert.ok(pageSource.includes("pathname: '/sealos-skills'"));
   assert.ok(
     pageSource.includes('Sealos Skills: Deploy with Your AI Coding Agent'),
+  );
+  assert.ok(
+    pageSource.includes(
+      'Install Sealos Skills in Codex, Claude Code, Qoder, and other AI coding agents. Deploy apps, connect databases and S3, and verify rollouts on Sealos Cloud.',
+    ),
   );
   assert.ok(pageSource.includes("'@type': 'SoftwareApplication'"));
   assert.ok(pageSource.includes('generateHowToSchema({'));


### PR DESCRIPTION
This PR rewrites /sealos-skills into a Railway-style developer landing page with updated hero copy, evidence-first workflow sections, a revised support matrix, refreshed FAQ content, and SEO/schema updates.

Validation:
- node --test tests/sealos-skills-page.test.ts
- npm run lint
- npm run build
- npm run default-locale:check
- npm run static-routes:check
- npm run static-output:check
- git diff --check
- browser QA at 1440x1000 and 390x844