### PR TITLE
fix(auth): preserve email verification challenge

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/new-components/AuthForm/AuthFormContext.tsx
+++ b/new-components/AuthForm/AuthFormContext.tsx
@@ -2,13 +2,14 @@
 
 import { createContext, useContext, useState, useRef, ReactNode } from 'react';
 import { TurnstileInstance } from '@marsidev/react-turnstile';
-import { EmailVerifyRequest, EmailVerifyResponse } from './types';
+import { EmailVerifyResponse } from './types';
 
 type AuthStep = 'select-method' | 'verify-code';
 
 interface AuthFormData {
   email: string;
   captchaToken: string | null;
+  challengeId: string | null;
   startTime: number;
 }
 
@@ -57,6 +58,7 @@ export function AuthFormProvider({
   const [formData, setFormData] = useState<AuthFormData>({
     email: '',
     captchaToken: null,
+    challengeId: null,
     startTime: 0,
   });
   const [step, setStep] = useState<AuthStep>('select-method');
@@ -78,6 +80,8 @@ export function AuthFormProvider({
     setOpen(newOpen);
     if (!newOpen) {
       clearFormData();
+      setStep('select-method');
+      setError(null);
       setAdditionalParams(null);
     }
   };
@@ -106,6 +110,7 @@ export function AuthFormProvider({
     setFormData({
       email: '',
       captchaToken: null,
+      challengeId: null,
       startTime: 0,
     });
   };
@@ -119,9 +124,21 @@ export function AuthFormProvider({
 
       setIsSendingCode(true);
       setError(null);
+      setFormData((prev) => ({ ...prev, challengeId: null }));
 
-      await requestEmailCode(formData.email, formData.captchaToken);
+      const result = await requestEmailCode(
+        formData.email,
+        formData.captchaToken,
+      );
+      const challengeId = result.data?.challengeId;
+      if (!challengeId) {
+        throw new Error('Invalid verification challenge response');
+      }
 
+      setFormData((prev) => ({
+        ...prev,
+        challengeId,
+      }));
       updateStartTime();
       return true;
     } catch (error) {

--- a/new-components/AuthForm/VerifyCodeStep.tsx
+++ b/new-components/AuthForm/VerifyCodeStep.tsx
@@ -37,6 +37,10 @@ export function VerifyCodeStep() {
       setError('Please enter a 6-digit verification code');
       return;
     }
+    if (!formData.challengeId) {
+      setError('Verification session expired. Please request a new code.');
+      return;
+    }
 
     setIsVerifying(true);
     setError(null);
@@ -45,6 +49,7 @@ export function VerifyCodeStep() {
       const requestBody: EmailVerifyRequest = {
         code: verificationCode,
         id: formData.email,
+        challengeId: formData.challengeId,
       };
 
       const response = await fetch(siteConfig.emailVerifyEndpoint, {

--- a/new-components/AuthForm/types.ts
+++ b/new-components/AuthForm/types.ts
@@ -10,13 +10,18 @@ export interface EmailSmsRequest {
 export interface EmailSmsResponse {
   code: number;
   message: string;
-  data: null;
+  data: {
+    challengeId: string;
+    expiresIn: number;
+    resendAfter: number;
+  } | null;
 }
 
 // 验证验证码请求
 export interface EmailVerifyRequest {
   code: string; // verification code
   id: string; // email
+  challengeId: string;
 }
 
 // 验证验证码响应


### PR DESCRIPTION
## Summary

- preserve the `challengeId` returned by the email-code request
- include the same challenge in the verification request
- clear stale verification state when the auth dialog closes
- reject verification locally when no active challenge exists

## Root cause

The Sealos Desktop email verification API now binds each verification code to a per-send `challengeId`. The website still used the previous contract: it discarded the send response data and submitted only the email address and code. Production therefore rejected every website verification request with `400 INVALID_PARAMS` before checking the code.

## Impact

Email verification from sealos.io now follows the current Desktop API contract while retaining its single-use challenge security boundary. Existing OAuth and new-workspace redirects are unchanged.

## Validation

- `npm run lint`
- `npm run build` (6,179 static pages generated; AI FAQ route verification passed)
- production API contract probe with a random challenge reached `409 expired_code` instead of `400 INVALID_PARAMS`, confirming the request passes parameter validation
