### PR TITLE
fix: preserve attribution through Google One Tap

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,3 +49,10 @@ _Avoid_: Content check, release smoke
 The exported tutorial index, tutorial detail routes, and public evidence assets
 served to readers from the production static build.
 _Avoid_: Build output files, generated pages
+
+## Website Attribution Language
+
+**Attribution Handoff (归因交接)**:
+The transfer of acquisition context from the public website to a Sealos product
+surface during a cross-origin user journey.
+_Avoid_: CTA attribution, redirect tracking

--- a/new-components/AuthForm/GoogleOneTap.tsx
+++ b/new-components/AuthForm/GoogleOneTap.tsx
@@ -25,10 +25,7 @@ type OneTapLoginResponse = {
   };
 };
 
-export function buildOneTapRedirectUrl(data: {
-  token: string;
-  needInit?: boolean;
-}) {
+function buildOneTapRedirectUrl(data: { token: string; needInit?: boolean }) {
   const target = new URL(siteConfig.googleOneTap.redirectUrl || appDomain);
   if (target.pathname === '/') {
     target.pathname = '/oauth';

--- a/new-components/AuthForm/GoogleOneTap.tsx
+++ b/new-components/AuthForm/GoogleOneTap.tsx
@@ -3,6 +3,7 @@
 import Script from 'next/script';
 import { useCallback } from 'react';
 import { appDomain, siteConfig } from '@/config/site';
+import { appendAttributionToUrl } from '@/lib/attribution-url';
 
 type GoogleCredentialResponse = {
   credential?: string;
@@ -24,7 +25,10 @@ type OneTapLoginResponse = {
   };
 };
 
-function buildOneTapRedirectUrl(data: { token: string; needInit?: boolean }) {
+export function buildOneTapRedirectUrl(data: {
+  token: string;
+  needInit?: boolean;
+}) {
   const target = new URL(siteConfig.googleOneTap.redirectUrl || appDomain);
   if (target.pathname === '/') {
     target.pathname = '/oauth';
@@ -36,7 +40,7 @@ function buildOneTapRedirectUrl(data: { token: string; needInit?: boolean }) {
     target.searchParams.append('workspaceName', 'My Workspace');
   }
 
-  return target.toString();
+  return appendAttributionToUrl(target.toString());
 }
 
 declare global {

--- a/scripts/verify-attribution-url.mjs
+++ b/scripts/verify-attribution-url.mjs
@@ -188,6 +188,23 @@ assert.ok(
   'SelectMethodStep must decorate OAuth redirects before navigation',
 );
 
+const googleOneTapPath = resolve('new-components/AuthForm/GoogleOneTap.tsx');
+const googleOneTapSource = await readFile(googleOneTapPath, 'utf8');
+assert.match(googleOneTapSource, /from ['"]@\/lib\/attribution-url['"]/);
+assert.match(
+  googleOneTapSource,
+  /export function buildOneTapRedirectUrl/,
+  'GoogleOneTap must expose its redirect builder for regression coverage',
+);
+const googleOneTapCall = googleOneTapSource.indexOf(
+  'appendAttributionToUrl(target.toString())',
+);
+const googleOneTapHref = googleOneTapSource.indexOf('window.location.href');
+assert.ok(
+  googleOneTapCall >= 0 && googleOneTapCall < googleOneTapHref,
+  'GoogleOneTap must decorate the final login redirect before navigation',
+);
+
 const deployModalSource = await readFile(
   resolve('new-components/DeployModal/DeployModalContext.tsx'),
   'utf8',
@@ -266,6 +283,66 @@ vm.runInNewContext(authCode, hookSandbox, { filename: authPath });
 const { buildAuthRedirectUrl } = hookModule.exports;
 
 assert.equal(typeof buildAuthRedirectUrl, 'function');
+
+const googleOneTapCode = ts.transpileModule(googleOneTapSource, {
+  compilerOptions: {
+    jsx: ts.JsxEmit.ReactJSX,
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2022,
+  },
+}).outputText;
+
+const googleOneTapModule = { exports: {} };
+const googleOneTapSandbox = {
+  module: googleOneTapModule,
+  exports: googleOneTapModule.exports,
+  require(specifier) {
+    if (specifier === 'next/script') {
+      return { __esModule: true, default: () => null };
+    }
+
+    if (specifier === 'react') {
+      return { useCallback: (fn) => fn };
+    }
+
+    if (specifier === 'react/jsx-runtime') {
+      return { jsx: () => null };
+    }
+
+    if (specifier === '@/config/site') {
+      return {
+        appDomain: 'https://os.sealos.io',
+        siteConfig: {
+          googleOneTap: {
+            clientId: 'test-client',
+            enabled: true,
+            loginEndpoint: '/api/auth/google/onetap',
+            redirectUrl: 'https://os.sealos.io',
+          },
+        },
+      };
+    }
+
+    if (specifier === '@/lib/attribution-url') {
+      return { appendAttributionToUrl };
+    }
+
+    throw new Error(`Unexpected import: ${specifier}`);
+  },
+  console,
+  fetch: async () => ({ json: async () => ({}) }),
+  URL,
+  URLSearchParams,
+};
+
+googleOneTapSandbox.globalThis = googleOneTapSandbox;
+googleOneTapSandbox.window = globalThis.window;
+vm.runInNewContext(googleOneTapCode, googleOneTapSandbox, {
+  filename: googleOneTapPath,
+});
+const { buildOneTapRedirectUrl } = googleOneTapModule.exports;
+
+assert.equal(typeof buildOneTapRedirectUrl, 'function');
 
 const previousWindow = globalThis.window;
 const previousDocument = globalThis.document;
@@ -418,6 +495,29 @@ try {
     buildAuthRedirectUrl({ openapp: 'system-brain' }),
     `${oauth2Url}?openapp=system-brain&sea_attr=runtime`,
   );
+
+  const oneTapRedirect = new URL(
+    buildOneTapRedirectUrl({ token: 'test-token', needInit: true }),
+  );
+  assert.equal(oneTapRedirect.pathname, '/oauth');
+  assert.equal(oneTapRedirect.searchParams.get('token'), 'test-token');
+  assert.equal(oneTapRedirect.searchParams.get('switchRegionType'), 'INIT');
+  assert.equal(
+    oneTapRedirect.searchParams.get('workspaceName'),
+    'My Workspace',
+  );
+  assert.equal(oneTapRedirect.searchParams.get('sea_attr'), 'runtime');
+
+  setBrowserFixtures({ href: 'https://sealos.io/' });
+  const unattributedOneTapRedirect = new URL(
+    buildOneTapRedirectUrl({ token: 'test-token' }),
+  );
+  assert.equal(unattributedOneTapRedirect.pathname, '/oauth');
+  assert.equal(
+    unattributedOneTapRedirect.searchParams.get('token'),
+    'test-token',
+  );
+  assert.equal(unattributedOneTapRedirect.searchParams.has('sea_attr'), false);
 } finally {
   restoreBrowserFixtures();
 }

--- a/scripts/verify-attribution-url.mjs
+++ b/scripts/verify-attribution-url.mjs
@@ -188,14 +188,11 @@ assert.ok(
   'SelectMethodStep must decorate OAuth redirects before navigation',
 );
 
-const googleOneTapPath = resolve('new-components/AuthForm/GoogleOneTap.tsx');
-const googleOneTapSource = await readFile(googleOneTapPath, 'utf8');
-assert.match(googleOneTapSource, /from ['"]@\/lib\/attribution-url['"]/);
-assert.match(
-  googleOneTapSource,
-  /export function buildOneTapRedirectUrl/,
-  'GoogleOneTap must expose its redirect builder for regression coverage',
+const googleOneTapSource = await readFile(
+  resolve('new-components/AuthForm/GoogleOneTap.tsx'),
+  'utf8',
 );
+assert.match(googleOneTapSource, /from ['"]@\/lib\/attribution-url['"]/);
 const googleOneTapCall = googleOneTapSource.indexOf(
   'appendAttributionToUrl(target.toString())',
 );
@@ -283,66 +280,6 @@ vm.runInNewContext(authCode, hookSandbox, { filename: authPath });
 const { buildAuthRedirectUrl } = hookModule.exports;
 
 assert.equal(typeof buildAuthRedirectUrl, 'function');
-
-const googleOneTapCode = ts.transpileModule(googleOneTapSource, {
-  compilerOptions: {
-    jsx: ts.JsxEmit.ReactJSX,
-    module: ts.ModuleKind.CommonJS,
-    target: ts.ScriptTarget.ES2022,
-  },
-}).outputText;
-
-const googleOneTapModule = { exports: {} };
-const googleOneTapSandbox = {
-  module: googleOneTapModule,
-  exports: googleOneTapModule.exports,
-  require(specifier) {
-    if (specifier === 'next/script') {
-      return { __esModule: true, default: () => null };
-    }
-
-    if (specifier === 'react') {
-      return { useCallback: (fn) => fn };
-    }
-
-    if (specifier === 'react/jsx-runtime') {
-      return { jsx: () => null };
-    }
-
-    if (specifier === '@/config/site') {
-      return {
-        appDomain: 'https://os.sealos.io',
-        siteConfig: {
-          googleOneTap: {
-            clientId: 'test-client',
-            enabled: true,
-            loginEndpoint: '/api/auth/google/onetap',
-            redirectUrl: 'https://os.sealos.io',
-          },
-        },
-      };
-    }
-
-    if (specifier === '@/lib/attribution-url') {
-      return { appendAttributionToUrl };
-    }
-
-    throw new Error(`Unexpected import: ${specifier}`);
-  },
-  console,
-  fetch: async () => ({ json: async () => ({}) }),
-  URL,
-  URLSearchParams,
-};
-
-googleOneTapSandbox.globalThis = googleOneTapSandbox;
-googleOneTapSandbox.window = globalThis.window;
-vm.runInNewContext(googleOneTapCode, googleOneTapSandbox, {
-  filename: googleOneTapPath,
-});
-const { buildOneTapRedirectUrl } = googleOneTapModule.exports;
-
-assert.equal(typeof buildOneTapRedirectUrl, 'function');
 
 const previousWindow = globalThis.window;
 const previousDocument = globalThis.document;
@@ -495,29 +432,6 @@ try {
     buildAuthRedirectUrl({ openapp: 'system-brain' }),
     `${oauth2Url}?openapp=system-brain&sea_attr=runtime`,
   );
-
-  const oneTapRedirect = new URL(
-    buildOneTapRedirectUrl({ token: 'test-token', needInit: true }),
-  );
-  assert.equal(oneTapRedirect.pathname, '/oauth');
-  assert.equal(oneTapRedirect.searchParams.get('token'), 'test-token');
-  assert.equal(oneTapRedirect.searchParams.get('switchRegionType'), 'INIT');
-  assert.equal(
-    oneTapRedirect.searchParams.get('workspaceName'),
-    'My Workspace',
-  );
-  assert.equal(oneTapRedirect.searchParams.get('sea_attr'), 'runtime');
-
-  setBrowserFixtures({ href: 'https://sealos.io/' });
-  const unattributedOneTapRedirect = new URL(
-    buildOneTapRedirectUrl({ token: 'test-token' }),
-  );
-  assert.equal(unattributedOneTapRedirect.pathname, '/oauth');
-  assert.equal(
-    unattributedOneTapRedirect.searchParams.get('token'),
-    'test-token',
-  );
-  assert.equal(unattributedOneTapRedirect.searchParams.has('sea_attr'), false);
 } finally {
   restoreBrowserFixtures();
 }


### PR DESCRIPTION
## Summary

- pass the existing website attribution payload through the Google One Tap redirect
- preserve the current token and workspace initialization parameters
- document the Attribution Handoff domain term
- add a regression guard for the One Tap attribution boundary

## Root cause

Google One Tap built and assigned its final product URL directly. Other website authentication and CTA paths use `appendAttributionToUrl`, so One Tap sessions dropped `sea_attr` during the cross-origin redirect.

## Verification

- `node scripts/verify-attribution-url.mjs`
- `git diff --check`
- `npx prettier --check new-components/AuthForm/GoogleOneTap.tsx CONTEXT.md`

The repository-wide `npm run lint` currently reports five pre-existing `StaticImageData` assignment errors in `app/[lang]/(home)/(new-home)/sections/comparison-section.tsx`.
