### PR TITLE
fix(auth): reset Turnstile after email request failure

### DIFF
--- a/new-components/AuthForm/SelectMethodStep.tsx
+++ b/new-components/AuthForm/SelectMethodStep.tsx
@@ -58,6 +58,7 @@ export function SelectMethodStep() {
       setStep('verify-code');
     } else {
       handleCaptchaError();
+      turnstileRef.current?.reset();
     }
   };
 

--- a/new-components/AuthForm/select-method-step.test.mts
+++ b/new-components/AuthForm/select-method-step.test.mts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const source = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), 'SelectMethodStep.tsx'),
+  'utf8',
+);
+
+test('email request failures reset Turnstile before retrying', () => {
+  assert.match(
+    source,
+    /if \(success\) \{[\s\S]*setStep\('verify-code'\);[\s\S]*\} else \{[\s\S]*handleCaptchaError\(\);[\s\S]*turnstileRef\.current\?\.reset\(\);[\s\S]*\}/,
+  );
+});


### PR DESCRIPTION
## What changed

- Reset the email sign-in Turnstile widget when requesting a verification code fails.
- Add a focused regression test that locks the retry behavior.

## Why

Turnstile tokens expire and are single-use. The sign-in flow cleared its local captcha state after an email-code request failure, but left the widget in its completed state. A retry could therefore remain blocked or reuse a consumed token instead of generating a fresh one.

This keeps the existing fail-closed behavior: users must complete a fresh Turnstile challenge before retrying. It does not split site keys or change `action`/`cData`, because the authentication backend currently validates token success rather than those metadata fields.

## Validation

- `npm exec --yes tsx -- --test new-components/AuthForm/select-method-step.test.mts`
- `npm run lint`
- `git diff --check`