### PR TITLE
feat: ship Railway Alternative and analytics contract

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,7 +1,7 @@
-# Tutorial Publishing
+# Shared Product Language
 
-This context defines the shared language used to plan and publish framework
-tutorial paths under `/tutorials`.
+This context defines the shared language used across tutorial publishing,
+website attribution, and competitor acquisition work.
 
 ## Language
 
@@ -56,3 +56,21 @@ _Avoid_: Build output files, generated pages
 The transfer of acquisition context from the public website to a Sealos product
 surface during a cross-origin user journey.
 _Avoid_: CTA attribution, redirect tracking
+
+## Competitor Acquisition Language
+
+**Alternative Page**:
+A high-intent acquisition page for visitors evaluating a named competitor
+replacement and selecting a concrete next action.
+_Avoid_: Comparison Page, migration automation
+
+**Comparison Page**:
+A neutral product-evaluation page that explains differences and workload fit
+between two platforms.
+_Avoid_: Alternative Page, campaign landing page
+
+**Deployment Intent**:
+The concrete deployment task selected by a visitor and carried through an
+Attribution Handoff, such as `github_repo` or `docker_image`; `unselected`
+records a research CTA before a deployment task is chosen.
+_Avoid_: Generic signup, CTA click

--- a/app/[lang]/(home)/(new-home)/components/deploy-demos/deploy-demo-common.tsx
+++ b/app/[lang]/(home)/(new-home)/components/deploy-demos/deploy-demo-common.tsx
@@ -30,6 +30,11 @@ import { LayoutGroup, motion, useReducedMotion } from 'motion/react';
 
 import { cn } from '@/lib/utils';
 
+import {
+  getNextPlaybackState,
+  getRemainingDuration,
+} from './deploy-demo-playback.mjs';
+
 export type CursorStep = {
   cursor: { x: number; y: number };
   clickTarget?: string;
@@ -104,10 +109,16 @@ const modeCards = [
 export function useDemoPlayback<TStep extends CursorStep>({
   active = true,
   getTargetId,
+  loop = true,
+  onComplete,
+  paused = false,
   steps,
 }: {
   active?: boolean;
   getTargetId: (step: TStep) => string | undefined;
+  loop?: boolean;
+  onComplete?: () => void;
+  paused?: boolean;
   steps: TStep[];
 }) {
   const prefersReducedMotion = useReducedMotion();
@@ -115,6 +126,8 @@ export function useDemoPlayback<TStep extends CursorStep>({
   const stageRef = useRef<HTMLDivElement>(null);
   const [stepIndex, setStepIndex] = useState(0);
   const [progress, setProgress] = useState(0);
+  const progressRef = useRef(0);
+  const completionNotifiedRef = useRef(false);
   const [cursorPosition, setCursorPosition] = useState<{
     x: number;
     y: number;
@@ -138,32 +151,58 @@ export function useDemoPlayback<TStep extends CursorStep>({
   }, []);
 
   useEffect(() => {
-    if (!active && !reduceMotion) {
+    if (!active) {
+      progressRef.current = 0;
+      completionNotifiedRef.current = false;
       setStepIndex(0);
       setProgress(0);
     }
-  }, [active, reduceMotion]);
+  }, [active]);
 
   useEffect(() => {
-    if (reduceMotion || !active) return;
+    if (reduceMotion || !active || paused) return;
 
-    const startedAt = performance.now();
     const duration = steps[stepIndex].duration;
-    setProgress(0);
+    const remainingDuration = getRemainingDuration(
+      duration,
+      progressRef.current,
+    );
+    const startedAt = performance.now() - (duration - remainingDuration);
 
     const interval = window.setInterval(() => {
-      setProgress(Math.min(1, (performance.now() - startedAt) / duration));
+      const nextProgress = Math.min(
+        1,
+        (performance.now() - startedAt) / duration,
+      );
+      progressRef.current = nextProgress;
+      setProgress(nextProgress);
     }, 50);
     const timeout = window.setTimeout(() => {
-      setProgress(0);
-      setStepIndex((index) => (index + 1) % steps.length);
-    }, duration);
+      const nextState = getNextPlaybackState({
+        index: stepIndex,
+        loop,
+        stepCount: steps.length,
+      });
+
+      progressRef.current = nextState.progress;
+      setProgress(nextState.progress);
+
+      if (nextState.completed) {
+        if (!completionNotifiedRef.current) {
+          completionNotifiedRef.current = true;
+          onComplete?.();
+        }
+        return;
+      }
+
+      setStepIndex(nextState.index);
+    }, remainingDuration);
 
     return () => {
       window.clearInterval(interval);
       window.clearTimeout(timeout);
     };
-  }, [active, reduceMotion, stepIndex, steps]);
+  }, [active, loop, onComplete, paused, reduceMotion, stepIndex, steps]);
 
   useLayoutEffect(() => {
     const stage = stageRef.current;

--- a/app/[lang]/(home)/(new-home)/components/deploy-demos/deploy-demo-playback.mjs
+++ b/app/[lang]/(home)/(new-home)/components/deploy-demos/deploy-demo-playback.mjs
@@ -1,0 +1,34 @@
+/**
+ * @param {number} value
+ */
+function clampProgress(value) {
+  return Math.min(1, Math.max(0, value));
+}
+
+/**
+ * @param {number} duration
+ * @param {number} progress
+ */
+export function getRemainingDuration(duration, progress) {
+  return Math.max(0, duration) * (1 - clampProgress(progress));
+}
+
+/**
+ * @typedef {{ index: number, loop: boolean, stepCount: number }} PlaybackStateInput
+ */
+
+/**
+ * @param {PlaybackStateInput} input
+ */
+export function getNextPlaybackState({ index, loop, stepCount }) {
+  const finalIndex = Math.max(0, stepCount - 1);
+  const currentIndex = Math.min(finalIndex, Math.max(0, index));
+
+  if (currentIndex < finalIndex) {
+    return { completed: false, index: currentIndex + 1, progress: 0 };
+  }
+
+  return loop
+    ? { completed: false, index: 0, progress: 0 }
+    : { completed: true, index: finalIndex, progress: 1 };
+}

--- a/app/[lang]/(home)/(new-home)/components/deploy-demos/deployment-canvas.tsx
+++ b/app/[lang]/(home)/(new-home)/components/deploy-demos/deployment-canvas.tsx
@@ -83,10 +83,12 @@ const canvasConfigs: Record<DeploymentCanvasVariant, DeploymentCanvasConfig> = {
 
 export function DeploymentCanvas({
   readyStage,
+  runtimeStatus,
   shifted = false,
   variant,
 }: {
   readyStage: number;
+  runtimeStatus?: DeploymentCanvasConfig['runtimeStatus'];
   shifted?: boolean;
   variant: DeploymentCanvasVariant;
 }) {
@@ -94,7 +96,7 @@ export function DeploymentCanvas({
   const showRuntime = readyStage >= 4;
   const accessStage = config.accessStage;
   const showAccess = accessStage !== undefined && readyStage >= accessStage;
-  const status = config.runtimeStatus ?? 'Creating';
+  const status = runtimeStatus ?? config.runtimeStatus ?? 'Creating';
 
   return (
     <div

--- a/app/[lang]/(home)/(new-home)/components/deploy-demos/github-import-demo.tsx
+++ b/app/[lang]/(home)/(new-home)/components/deploy-demos/github-import-demo.tsx
@@ -206,12 +206,95 @@ const githubSteps: GithubStep[] = shortenDemoSteps<GithubStep>([
   },
 ]);
 
+const compactGithubSteps: GithubStep[] = shortenDemoSteps<GithubStep>([
+  {
+    duration: 2000,
+    screen: 'form',
+    cursor: { x: 72, y: 74 },
+    authorized: true,
+    expanded: true,
+  },
+  {
+    duration: 900,
+    screen: 'form',
+    cursor: { x: 78, y: 74 },
+    authorized: true,
+    expanded: true,
+    clickTarget: 'repoDeploy',
+  },
+  {
+    duration: 1400,
+    screen: 'ready',
+    cursor: { x: 58, y: 48 },
+    readyStage: 0,
+    holdCursor: true,
+  },
+  {
+    duration: 1400,
+    screen: 'ready',
+    cursor: { x: 58, y: 48 },
+    readyStage: 4,
+    holdCursor: true,
+  },
+  {
+    duration: 1400,
+    screen: 'ready',
+    cursor: { x: 58, y: 48 },
+    readyStage: 7,
+    holdCursor: true,
+  },
+  {
+    duration: 1400,
+    screen: 'ready',
+    cursor: { x: 58, y: 48 },
+    readyStage: 12,
+    holdCursor: true,
+  },
+  {
+    duration: 1400,
+    screen: 'ready',
+    cursor: { x: 58, y: 48 },
+    readyStage: 14,
+    holdCursor: true,
+  },
+  {
+    duration: 1600,
+    screen: 'ready',
+    cursor: { x: 58, y: 48 },
+    readyStage: 15,
+    holdCursor: true,
+  },
+  {
+    duration: 6000,
+    screen: 'ready',
+    cursor: { x: 58, y: 48 },
+    formClosed: true,
+    readyStage: 15,
+    holdCursor: true,
+  },
+]);
+
 export const githubImportDemoDurationMs = githubSteps.reduce(
   (total, step) => total + step.duration,
   0,
 );
 
-export function GitHubImportDemo({ active = true }: { active?: boolean }) {
+type GitHubImportDemoProps = {
+  active?: boolean;
+  loop?: boolean;
+  onComplete?: () => void;
+  paused?: boolean;
+  variant?: 'compact' | 'full';
+};
+
+export function GitHubImportDemo({
+  active = true,
+  loop = true,
+  onComplete,
+  paused = false,
+  variant = 'full',
+}: GitHubImportDemoProps) {
+  const steps = variant === 'compact' ? compactGithubSteps : githubSteps;
   const {
     actionProgress,
     actionReady,
@@ -225,15 +308,18 @@ export function GitHubImportDemo({ active = true }: { active?: boolean }) {
   } = useDemoPlayback({
     active,
     getTargetId: getGithubStepTarget,
-    steps: githubSteps,
+    loop,
+    onComplete,
+    paused,
+    steps,
   });
   const readyStage = reduceMotion ? 15 : step.readyStage;
   const secret = reduceMotion
     ? githubFinalValues.secret
-    : getGithubFieldText('secret', effectiveIndex, actionProgress);
+    : getGithubFieldText('secret', effectiveIndex, actionProgress, steps);
   const activeField = actionReady
     ? step.activeField
-    : getPreviousGithubField(effectiveIndex);
+    : getPreviousGithubField(effectiveIndex, steps);
 
   return (
     <DemoStageShell
@@ -242,6 +328,9 @@ export function GitHubImportDemo({ active = true }: { active?: boolean }) {
         step.screen === 'ready' ? (
           <DeploymentCanvas
             readyStage={readyStage ?? 0}
+            runtimeStatus={
+              variant === 'compact' && readyStage === 15 ? 'Running' : undefined
+            }
             shifted={!step.formClosed}
             variant="github"
           />
@@ -317,15 +406,16 @@ function getGithubFieldText(
   field: GithubFieldId,
   index: number,
   progress: number,
+  steps: GithubStep[],
 ) {
-  const step = githubSteps[index];
-  const target = getLatestGithubFieldValue(field, index);
+  const step = steps[index];
+  const target = getLatestGithubFieldValue(field, index, steps);
 
   if (step.activeField !== field || step.typed?.[field] === undefined) {
     return target;
   }
 
-  const previous = getLatestGithubFieldValue(field, index - 1);
+  const previous = getLatestGithubFieldValue(field, index - 1, steps);
   const next = step.typed[field] ?? '';
   const localProgress = Math.min(1, Math.max(0, progress));
 
@@ -337,18 +427,22 @@ function getGithubFieldText(
   return next.slice(0, Math.round(next.length * localProgress));
 }
 
-function getLatestGithubFieldValue(field: GithubFieldId, index: number) {
+function getLatestGithubFieldValue(
+  field: GithubFieldId,
+  index: number,
+  steps: GithubStep[],
+) {
   for (let i = index; i >= 0; i -= 1) {
-    const value = githubSteps[i]?.typed?.[field];
+    const value = steps[i]?.typed?.[field];
     if (value !== undefined) return value;
   }
 
   return '';
 }
 
-function getPreviousGithubField(index: number) {
+function getPreviousGithubField(index: number, steps: GithubStep[]) {
   for (let i = index - 1; i >= 0; i -= 1) {
-    const field = githubSteps[i]?.activeField;
+    const field = steps[i]?.activeField;
     if (field) return field;
   }
 }

--- a/app/[lang]/(home)/comparison/config/faqs.ts
+++ b/app/[lang]/(home)/comparison/config/faqs.ts
@@ -1,7 +1,6 @@
 import { railwayComparablePlans } from '../../pricing/config/plans';
 import {
   RAILWAY_RATE_CARD,
-  calculateCostDifference,
   estimateRailwayMonthlyCost,
   formatUsd,
 } from '../../pricing/config/railway-cost';
@@ -714,16 +713,12 @@ This is a key difference from Google App Engine, which runs only on GCP infrastr
     volumeGb: 50,
     egressGb: 100,
   });
-  const railwayMediumDifference = calculateCostDifference(
-    standardPlan.monthlyPrice,
-    railwayMediumEstimate.total,
-  );
-
+  const railwayMediumPlan =
+    RAILWAY_RATE_CARD.plans[railwayMediumEstimate.selectedPlan];
   return [
     {
-      question:
-        'How much can I actually save by switching from Railway to Sealos?',
-      answer: `For this full-utilization medium workload, the Sealos Standard plan is about **${railwayMediumDifference.percentage}% lower** than the Railway estimate.
+      question: 'How does the Railway estimate compare with Sealos?',
+      answer: `For this full-utilization medium workload, the Sealos Standard plan is ${formatUsd(standardPlan.monthlyPrice)} and the Railway ${railwayMediumPlan.name} estimate is ${formatUsd(railwayMediumEstimate.billedTotal)}.
 
 **Example calculation for a medium app (8 vCPU, 16GB RAM, 24/7):**
 
@@ -732,21 +727,15 @@ This is a key difference from Google App Engine, which runs only on GCP infrastr
 | Compute (monthly) | ${formatUsd(railwayMediumEstimate.cpu + railwayMediumEstimate.ram)} | Included |
 | 50GB volume | ${formatUsd(railwayMediumEstimate.volume)} | Included |
 | 100GB egress | ${formatUsd(railwayMediumEstimate.egress)} | Included |
-| **Total** | **~${formatUsd(railwayMediumEstimate.total)}/mo** | **${formatUsd(standardPlan.monthlyPrice)}/mo** |
+| **Total** | **~${formatUsd(railwayMediumEstimate.billedTotal)}/mo** | **${formatUsd(standardPlan.monthlyPrice)}/mo** |
 
-This is a rate-card estimate. Low-utilization workloads can cost less on Railway. Railway also provides hard usage limits that shut down workloads at the selected limit.`,
+This is a rate-card estimate for the documented workload. The shared estimator applies the ${railwayMediumPlan.name} minimum and confirms ${railwayMediumEstimate.resourceEligibility.eligible ? 'resource eligibility' : railwayMediumEstimate.validationResult.message}. Verify the current terms in [Railway pricing documentation](${RAILWAY_RATE_CARD.sourceUrl}), checked ${RAILWAY_RATE_CARD.verifiedAt}. Use the [Railway alternative page](/railway-alternative/) for migration fit and the [pricing calculator](/pricing/#railway-cost) for your own inputs. Actual billing follows measured resource usage, plan terms, regional pricing, and provider changes.`,
     },
     {
-      question: "What's included in Sealos that costs extra on Railway?",
-      answer: `Several things that Railway charges separately are included in Sealos plans:
+      question: 'How do the billing models differ?',
+      answer: `Sealos packages defined CPU, memory, disk, and traffic resources in a monthly plan. Railway measures resource usage and applies the selected plan's minimum and included usage.
 
-| Feature | Railway | Sealos |
-|---------|---------|--------|
-| Database hosting | Metered separately | Included in plan quota |
-| Object storage | $0.015/GB-month | Included (S3-compatible) |
-| Egress bandwidth | $0.05/GB | Generous allowance (50GB-3TB) |
-| Build minutes | Counted against usage | Unlimited |
-| Custom domains | Hobby: 2, Pro: 20 | Unlimited |`,
+Use the linked rate card and enter your own workload in the pricing calculator for a current estimate. Railway plan terms were verified ${RAILWAY_RATE_CARD.verifiedAt}.`,
     },
     {
       question: 'Can I verify these claims myself?',
@@ -760,37 +749,33 @@ This is a rate-card estimate. Low-utilization workloads can cost less on Railway
 We encourage you to verify and calculate based on your specific workload.`,
     },
     {
-      question: 'How long does it take to migrate from Railway to Sealos?',
-      answer: `Typical migrations complete in **10–14 days**. Here's what the process looks like:
+      question: 'What is a practical Railway-to-Sealos migration path?',
+      answer: `Use a workload-specific migration checklist without assuming a fixed timeline:
 
-**Week 1: Assessment & Setup**
-- Our team audits your Railway services, databases, and environment variables
-- We provision equivalent resources on Sealos and configure networking
-
-**Week 2: Migration & Validation**
-- Data migration with zero-downtime cutover strategy
-- CI/CD pipeline reconfiguration
-- Production validation and traffic switchover`,
+1. Provision the destination application and data services.
+2. Copy configuration and export/import data with a maintenance window.
+3. Verify connections, health checks, logs, and public behavior.
+4. Cut over the domain after the data gate passes.`,
     },
     {
       question: 'Do we need Kubernetes expertise to use Sealos?',
-      answer: `**No.** DevBox and App Launchpad abstract Kubernetes primitives completely. You can:
+      answer: `DevBox and App Launchpad provide a managed workflow for common tasks. You can:
 - Deploy apps with a single click or natural language prompt
 - Manage databases without touching YAML
 - Scale services with simple UI controls
 
-Platform teams who want deeper control can still access native Kubernetes APIs, \`kubectl\`, and Helm when needed. Sealos gives you **simplicity by default, power when required**.`,
+Platform teams who want deeper control can still access native Kubernetes APIs, \`kubectl\`, and Helm when needed.`,
     },
     {
       question:
         'Can Sealos run in a private region or on our own infrastructure?',
-      answer: `**Yes.** Because Sealos is 100% source-available, you have full deployment flexibility:
+      answer: `Sealos supports multiple deployment models:
 
 - **Sealos Cloud**: Fully managed service in multiple regions
 - **Self-hosted**: Deploy on your own AWS, GCP, Azure, or bare metal
 - **Hybrid**: Mix cloud and on-premise for compliance requirements
 
-This is a key difference from Railway, which only offers cloud deployment (BYO Cloud is Enterprise-only). With Sealos, you're never locked in.`,
+Railway focuses on its managed cloud platform, while Sealos also supports source-available deployment options. Railway deployment and plan terms were checked ${RAILWAY_RATE_CARD.verifiedAt} in [official documentation](${RAILWAY_RATE_CARD.sourceUrl}).`,
     },
   ];
 }

--- a/app/[lang]/(home)/comparison/config/railway.tsx
+++ b/app/[lang]/(home)/comparison/config/railway.tsx
@@ -40,15 +40,19 @@ const comparableSealosPrices = ['hobby', 'standard', 'pro'].map(
     railwayComparablePlans.find((plan) => plan.planId === planId)!.monthlyPrice,
 );
 
+const railwayPlanEvidence = `See [Railway plans](${RAILWAY_RATE_CARD.sourceUrl}), verified ${RAILWAY_RATE_CARD.verifiedAt}.`;
+const railwayDeploymentEvidence = `See [Railway deployment guides](${RAILWAY_RATE_CARD.deploymentSourceUrl}), verified ${RAILWAY_RATE_CARD.verifiedAt}.`;
+
 const railwayCostRows = railwayWorkloadInputs.map((input, index) => {
   const estimate = estimateRailwayMonthlyCost(input);
   const difference = calculateCostDifference(
     comparableSealosPrices[index],
-    estimate.total,
+    estimate.billedTotal,
   );
+  const railwayPlan = RAILWAY_RATE_CARD.plans[estimate.selectedPlan];
 
   return {
-    cost: `~${formatUsd(estimate.total)}/mo`,
+    cost: `~${formatUsd(estimate.billedTotal)}/mo`,
     sealosSavings: {
       type: 'comparable' as const,
       savings:
@@ -56,7 +60,7 @@ const railwayCostRows = railwayWorkloadInputs.map((input, index) => {
           ? difference.percentage
           : -difference.percentage,
     },
-    label: 'Railway usage estimate',
+    label: `Railway ${railwayPlan.name} estimate · ${formatUsd(estimate.planMinimum)} minimum · ${estimate.resourceEligibility.eligible ? 'eligible' : estimate.validationResult.message}`,
   };
 });
 
@@ -66,13 +70,15 @@ export const railwayConfig: ComparisonConfig = {
   order: 1,
   content: {
     overview:
-      'Railway is a managed Platform-as-a-Service (PaaS) that simplifies application deployment through Git integration and usage-based billing. It automates builds and deploys for web services, background workers, Cron Jobs, and databases. Railway provides a fast path from code to production with automatic scaling (including scale-to-zero), abstracting away infrastructure complexity for individual developers and small teams.',
+      'Railway is a managed Platform-as-a-Service (PaaS) that simplifies application deployment through Git integration and usage-based billing. It automates builds and deploys for web services, background workers, Cron Jobs, and databases. Railway provides a fast path from code to production while abstracting away infrastructure complexity for individual developers and small teams.',
     pricing: `Railway Usage-Based Rates:
 • Hobby subscription: $${RAILWAY_RATE_CARD.hobbyMonthlySubscription}/month, including $${RAILWAY_RATE_CARD.hobbyIncludedUsage} of resource usage
+• Pro subscription: $${RAILWAY_RATE_CARD.proMonthlySubscription}/month, including $${RAILWAY_RATE_CARD.proIncludedUsage} of resource usage
 • CPU: $${RAILWAY_RATE_CARD.cpuPerVcpuMonth}/vCPU-month
 • Memory: $${RAILWAY_RATE_CARD.ramPerGbMonth}/GB-month
 • Egress: $${RAILWAY_RATE_CARD.egressPerGb}/GB
-• Volume storage: $${RAILWAY_RATE_CARD.volumePerGbMonth}/GB-month`,
+• Volume storage: $${RAILWAY_RATE_CARD.volumePerGbMonth}/GB-month
+• Verified ${RAILWAY_RATE_CARD.verifiedAt}: ${RAILWAY_RATE_CARD.sourceUrl}`,
     dimensions: {
       overview: {
         features: [
@@ -80,16 +86,16 @@ export const railwayConfig: ComparisonConfig = {
           { type: 'check', value: false },
           {
             type: 'text-multi-check',
-            value: ['Cloud only', 'BYO Cloud: Enterprise'],
+            value: ['Managed cloud', 'Plan-dependent'],
           },
-          { type: 'text', value: '30 days, $5 credit' },
-          { type: 'text', value: 'Hobby: 8, Pro: 32' },
-          { type: 'text', value: 'Hobby: 8GB, Pro: 32GB' },
-          { type: 'text', value: 'Hobby: 2, Pro: 20' },
-          { type: 'text', value: 'Hobby: 5, Pro: 50' },
-          { type: 'text', value: 'Hobby: 50, Pro: 100' },
-          { type: 'text', value: 'Free: 3d, Hobby: 7d, Pro: 30d' },
-          { type: 'text-with-check', value: '(saves on idle)' },
+          { type: 'text', value: 'Plan terms vary' },
+          { type: 'text', value: 'Plan-dependent' },
+          { type: 'text', value: 'Plan-dependent' },
+          { type: 'text', value: 'Plan-dependent' },
+          { type: 'text', value: 'Plan-dependent' },
+          { type: 'text', value: 'Plan-dependent' },
+          { type: 'text', value: 'Plan-dependent' },
+          { type: 'text', value: 'Usage-based billing' },
           { type: 'check', value: true },
         ],
         strengths: [],
@@ -109,32 +115,28 @@ export const railwayConfig: ComparisonConfig = {
           {
             icon: <GitCompare className="size-full" />,
             title: 'Streamlined Git-Push-to-Deploy',
-            content:
-              'Railway offers a remarkably streamlined git-push-to-deploy workflow with automatic buildpack detection—no configuration required for most frameworks.',
+            content: `Railway supports a streamlined Git-to-URL workflow for repository-based deployments. ${railwayDeploymentEvidence}`,
           },
           {
             icon: <CodeXml className="size-full" />,
             title: 'Preview Environments',
-            content:
-              "The platform's **Preview Environments** automatically spin up isolated instances for every pull request, making code review and testing seamless.",
+            content: `Railway preview environments can support pull-request testing when enabled for a project. ${railwayDeploymentEvidence}`,
           },
           {
             icon: <Settings className="size-full" />,
             title: 'CLI Tool Integration',
-            content:
-              "Railway's CLI tool (`railway run`) allows developers to run local code while connected to cloud-provisioned databases, bridging the local-cloud gap elegantly.",
+            content: `Railway's CLI provides a repository-adjacent workflow for local development and deployment tasks. ${railwayDeploymentEvidence}`,
           },
           {
             icon: <CodeXml className="size-full" />,
             title: 'Config-as-Code',
-            content:
-              'The `railway.toml` config-as-code approach keeps deployment settings versioned alongside your code.',
+            content: `Railway supports config-as-code workflows for keeping deployment settings with a repository. ${railwayDeploymentEvidence}`,
           },
         ],
         keyDifference: {
           title: 'Railway Approach',
           content:
-            "Railway prioritizes deployment simplicity through zero-config automation. Teams that want the fastest path from git push to production URL will appreciate Railway's streamlined workflow.",
+            'Railway prioritizes managed deployment simplicity. Teams that want a fast path from a repository to a production URL may find its workflow a good fit.',
         },
       },
       architecture: {
@@ -143,8 +145,8 @@ export const railwayConfig: ComparisonConfig = {
           { type: 'check', value: false },
           {
             type: 'warning',
-            value: 'Enterprise',
-            note: 'Available only on Railway Enterprise plan',
+            value: 'Plan-dependent',
+            note: railwayPlanEvidence,
           },
           { type: 'check', value: false },
           { type: 'check', value: false },
@@ -158,9 +160,8 @@ export const railwayConfig: ComparisonConfig = {
         strengths: [
           {
             icon: <TrendingUp className="size-full" />,
-            title: 'Scale-to-Zero',
-            content:
-              "Railway's automatic **scale-to-zero** capability is a standout feature for intermittent workloads. When your service receives no traffic for ~5-10 minutes, Railway automatically suspends the container and resumes it on the next request (with <1 second cold-start)—you only pay for actual usage.",
+            title: 'Usage-Based Scaling',
+            content: `Railway's usage-based billing supports intermittent workloads. See [Railway pricing documentation](${RAILWAY_RATE_CARD.sourceUrl}), verified ${RAILWAY_RATE_CARD.verifiedAt}.`,
           },
           {
             icon: <Box className="size-full" />,
@@ -170,21 +171,18 @@ export const railwayConfig: ComparisonConfig = {
           },
           {
             icon: <Globe className="size-full" />,
-            title: 'Multi-Region Deployment',
-            content:
-              'Railway also offers native **multi-region deployment** on Pro plans, allowing you to run replicas across US, Europe, and Asia simultaneously.',
+            title: 'Regional Deployment Options',
+            content: `Railway documents regional deployment options in its current plan documentation. ${railwayPlanEvidence}`,
           },
           {
             icon: <TrendingUp className="size-full" />,
-            title: 'Automatic Vertical Scaling',
-            content:
-              "The platform's **automatic vertical scaling** adjusts CPU/RAM allocation dynamically based on actual usage, without manual intervention.",
+            title: 'Managed Resource Controls',
+            content: `Railway provides managed resource controls; current limits vary by plan. ${railwayPlanEvidence}`,
           },
         ],
         keyDifference: {
           title: 'Railway Approach',
-          content:
-            'Railway provides maximum operational simplicity at the cost of vendor lock-in. Enterprise customers on Railway can access "Bring Your Own Cloud" for dedicated infrastructure, but this is a premium feature not available on standard plans.',
+          content: `Railway provides a managed experience focused on operational simplicity. Additional infrastructure options are documented in its current plan materials. ${railwayPlanEvidence}`,
         },
       },
       collaboration: {
@@ -196,59 +194,53 @@ export const railwayConfig: ComparisonConfig = {
           { type: 'check', value: true },
           {
             type: 'warning',
-            value: 'Pro',
-            note: 'Available only on Railway Pro plan',
+            value: 'Plan-dependent',
+            note: railwayPlanEvidence,
           },
           { type: 'check', value: true },
           { type: 'check', value: false },
           { type: 'check', value: true },
           {
             type: 'warning',
-            value: 'Enterprise',
-            note: 'Available only on Railway Enterprise plan',
+            value: 'Plan-dependent',
+            note: railwayPlanEvidence,
           },
           {
             type: 'warning',
-            value: 'Enterprise',
-            note: 'Available only on Railway Enterprise plan',
+            value: 'Plan-dependent',
+            note: railwayPlanEvidence,
           },
         ],
         strengths: [
           {
             icon: <Users className="size-full" />,
             title: 'Straightforward Team Model',
-            content:
-              'Railway offers a straightforward team model with three predefined roles (Admin, Developer, Deploy-only) that covers most use cases without complexity.',
+            content: `Railway documents a team model for managed deployment. ${railwayPlanEvidence}`,
           },
           {
             icon: <Users className="size-full" />,
-            title: 'Unlimited Team Seats',
-            content:
-              'The **Pro plan includes unlimited team seats** at no extra cost—a significant advantage for growing teams.',
+            title: 'Team Collaboration',
+            content: `Team collaboration terms vary by plan. ${railwayPlanEvidence}`,
           },
           {
             icon: <Network className="size-full" />,
             title: 'Private Network Isolation',
-            content:
-              'Each project has its own private network, providing natural isolation between environments.',
+            content: `Railway projects can use private networking for service-to-service communication. ${railwayDeploymentEvidence}`,
           },
           {
             icon: <Key className="size-full" />,
             title: 'Activity Feed & Audit Trail',
-            content:
-              'The activity feed provides a clear audit trail of all deployments and changes.',
+            content: `Railway provides deployment activity history for project operations. ${railwayDeploymentEvidence}`,
           },
           {
             icon: <Shield className="size-full" />,
             title: 'Enterprise Compliance',
-            content:
-              "For compliance-heavy industries, Railway's **Enterprise plan offers HIPAA/BAA compliance**, SSO/SAML integration, and 90-day audit logs.",
+            content: `Railway documents additional compliance and audit controls in its current plan materials. ${railwayPlanEvidence}`,
           },
         ],
         keyDifference: {
           title: 'Railway Approach',
-          content:
-            'Railway provides simpler team management that "just works" for most teams, with enterprise compliance features available at higher tiers.',
+          content: `Railway provides a managed team experience, with additional compliance features documented at higher tiers. ${railwayPlanEvidence}`,
         },
       },
       ecosystem: {
@@ -262,7 +254,7 @@ export const railwayConfig: ComparisonConfig = {
           { type: 'check', value: true },
           { type: 'check', value: false },
           { type: 'check', value: true },
-          { type: 'text', value: 'Hobby: 50, Pro: 100' },
+          { type: 'text', value: 'Plan-dependent' },
           { type: 'check', value: false },
           { type: 'check', value: false },
         ],
@@ -270,38 +262,33 @@ export const railwayConfig: ComparisonConfig = {
           {
             icon: <Wrench className="size-full" />,
             title: 'Polished Developer Experience',
-            content:
-              'Railway offers a polished, integrated developer experience for its managed services.',
+            content: `Railway offers an integrated developer experience for its managed services. ${railwayDeploymentEvidence}`,
           },
           {
             icon: <Database className="size-full" />,
             title: 'Built-in Database Viewer',
-            content:
-              'The **built-in database viewer** lets you browse tables, view records, and inspect Redis keys directly in the dashboard without external tools.',
+            content: `Railway's database tooling supports inspecting managed data services from the project workflow. ${railwayDeploymentEvidence}`,
           },
           {
             icon: <Settings className="size-full" />,
             title: 'First-Class Cron Jobs UI',
-            content:
-              '**Cron Jobs** get first-class UI treatment with visual scheduling, execution logs, and manual trigger buttons—Railway supports up to 50 cron jobs on Hobby and 100 on Pro plans.',
+            content: `Railway provides a managed cron-job workflow with current plan terms documented in its official materials. ${railwayPlanEvidence}`,
           },
           {
             icon: <Plug className="size-full" />,
             title: 'Tightly Integrated Services',
-            content:
-              'The platform\'s services (PostgreSQL, MySQL, MongoDB, Redis, storage buckets) are tightly integrated with the deployment workflow, providing a cohesive experience that "just works" without configuration.',
+            content: `Railway groups application and data services within a managed project workflow. ${railwayDeploymentEvidence}`,
           },
         ],
         keyDifference: {
           title: 'Railway Approach',
-          content:
-            "Railway offers a narrower but more polished set of built-in tools with superior UI/UX for common use cases. If you want the most streamlined experience for standard web apps with PostgreSQL/Redis, Railway's integrated tooling shines.",
+          content: `Railway offers an integrated managed workflow for common web applications and data services. ${railwayDeploymentEvidence}`,
         },
       },
     },
     costs: {
       rows: railwayCostRows,
-      note: `Estimate uses $${RAILWAY_RATE_CARD.cpuPerVcpuMonth}/vCPU-month and $${RAILWAY_RATE_CARD.ramPerGbMonth}/GB-month at the listed average usage. Volume and egress are excluded from these three examples. Verified ${RAILWAY_RATE_CARD.verifiedAt}.`,
+      note: `Each row uses estimateRailwayMonthlyCost() with automatic plan selection. Billed totals, plan minimums, included usage, and resource eligibility come from the shared estimate and rate card. Volume and egress are excluded from these three examples. ${railwayPlanEvidence}`,
       source: {
         url: RAILWAY_RATE_CARD.sourceUrl,
         label: 'Railway pricing documentation',
@@ -311,7 +298,7 @@ export const railwayConfig: ComparisonConfig = {
       {
         icon: <TrendingUp className="size-full" />,
         content:
-          'Have **intermittent workloads** that benefit from scale-to-zero billing',
+          'Have **intermittent workloads** that benefit from usage-based billing',
       },
       {
         icon: <DollarSign className="size-full" />,
@@ -330,11 +317,16 @@ export const railwayConfig: ComparisonConfig = {
       {
         icon: <Clock className="size-full" />,
         content:
-          "Run mostly **stateless, low-traffic hobby projects** near Railway's $5 Hobby minimum",
+          "Run mostly **stateless, low-traffic hobby projects** near Railway's Hobby subscription",
       },
       {
         icon: <CodeXml className="size-full" />,
         content: 'Want **Preview Environments** for pull request testing',
+      },
+      {
+        icon: <GitCompare className="size-full" />,
+        content:
+          'Ready to migrate or deploy? Read the [Railway alternative page](/railway-alternative/).',
       },
     ],
   },

--- a/app/[lang]/(home)/pricing/components/RailwayCostCalculator.tsx
+++ b/app/[lang]/(home)/pricing/components/RailwayCostCalculator.tsx
@@ -14,6 +14,7 @@ import SealosIcon from '@/assets/shared-icons/sealos.svg';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useGTM } from '@/hooks/use-gtm';
+import { getLanguageSlug } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
 import { railwayComparablePlans, type PricingPlanId } from '../config/plans';
 import {
@@ -121,6 +122,7 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
   }, [trackCustom]);
 
   const estimate = useMemo(() => estimateRailwayMonthlyCost(inputs), [inputs]);
+  const railwayPlan = RAILWAY_RATE_CARD.plans[estimate.selectedPlan];
   const difference = calculateCostDifference(
     selectedPlan.monthlyPrice,
     estimate.total,
@@ -131,6 +133,7 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
     ram: selectedPlan.resources.ram,
     volume: inputs.volumeGb,
     egress: inputs.egressGb,
+    railwayPlan: estimate.selectedPlan,
   });
 
   const handleUtilizationChange = (nextUtilization: Utilization) => {
@@ -177,14 +180,16 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
     }
   };
 
-  const comparisonMessage =
-    difference.lowerCost === 'equal'
+  const comparisonMessage = estimate.validationResult.valid
+    ? difference.lowerCost === 'equal'
       ? 'Both options have the same estimated monthly cost.'
-      : `${difference.lowerCost === 'sealos' ? 'Sealos' : 'Railway'} is estimated to cost ${formatUsd(difference.amount)} (${difference.percentage}%) less than ${difference.lowerCost === 'sealos' ? 'Railway' : 'Sealos'} in this example.`;
-  const lowerCostName =
-    difference.lowerCost === 'equal'
+      : `${difference.lowerCost === 'sealos' ? 'Sealos' : 'Railway'} is estimated to cost ${formatUsd(difference.amount)} (${difference.percentage}%) less than ${difference.lowerCost === 'sealos' ? 'Railway' : 'Sealos'} in this example.`
+    : estimate.validationResult.message;
+  const lowerCostName = estimate.validationResult.valid
+    ? difference.lowerCost === 'equal'
       ? 'Equal estimated cost'
-      : `${difference.lowerCost === 'sealos' ? 'Sealos' : 'Railway'} lower`;
+      : `${difference.lowerCost === 'sealos' ? 'Sealos' : 'Railway'} lower`
+    : 'Plan validation required';
   const currentComputeUtilization = Math.max(
     0,
     Math.min(
@@ -203,12 +208,15 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
   const getLowerCostAtUtilization = (percentage: number) =>
     calculateCostDifference(
       selectedPlan.monthlyPrice,
-      estimateRailwayMonthlyCost({
-        averageVcpu: selectedPlan.resources.cpu * (percentage / 100),
-        averageRamGb: selectedPlan.resources.ram * (percentage / 100),
-        volumeGb: inputs.volumeGb,
-        egressGb: inputs.egressGb,
-      }).total,
+      estimateRailwayMonthlyCost(
+        {
+          averageVcpu: selectedPlan.resources.cpu * (percentage / 100),
+          averageRamGb: selectedPlan.resources.ram * (percentage / 100),
+          volumeGb: inputs.volumeGb,
+          egressGb: inputs.egressGb,
+        },
+        estimate.selectedPlan,
+      ).total,
     ).lowerCost;
   const lowerCostAtZero = getLowerCostAtUtilization(0);
   const lowerCostAtFull = getLowerCostAtUtilization(100);
@@ -266,9 +274,19 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
             <p className="text-muted-foreground mt-4 max-w-2xl leading-7 text-pretty">
               Sealos provides the listed resources for a known monthly plan
               price. Railway bills measured CPU, memory, volume, and egress.
-              This estimate uses Railway Hobby’s $5 monthly subscription, which
-              includes $5 of resource usage.
+              This estimate uses Railway {railwayPlan.name}&apos;s{' '}
+              {formatUsd(estimate.planMinimum)} monthly subscription, which
+              includes {formatUsd(estimate.planIncludedUsage)} of resource
+              usage. {estimate.validationResult.message}
             </p>
+            <Link
+              href={`${getLanguageSlug(lang)}/railway-alternative/`}
+              onClick={() => handleSourceClick('railway_alternative_page')}
+              className="text-foreground mt-4 inline-flex items-center text-sm underline decoration-white/30 underline-offset-4 transition-colors hover:text-white focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:outline-none"
+            >
+              Evaluate the Railway alternative and migration path
+              <ArrowRight className="ml-1.5 size-3.5" />
+            </Link>
           </div>
           <div className="flex flex-col items-start gap-1 lg:items-end lg:text-right">
             <a
@@ -386,7 +404,7 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
                   />
                 </div>
                 <div>
-                  <p className="font-semibold">Railway</p>
+                  <p className="font-semibold">Railway {railwayPlan.name}</p>
                   <p className="text-muted-foreground text-sm">
                     Estimated usage bill
                   </p>
@@ -394,10 +412,13 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
               </div>
               <div className="flex flex-wrap gap-2">
                 <span className="border border-white/10 bg-white/5 px-2 py-1 text-xs font-medium text-zinc-200">
-                  Usage estimate
+                  {estimate.requiredPlan
+                    ? `${railwayPlan.name} required`
+                    : `${railwayPlan.name} eligible`}
                 </span>
                 <span className="border border-white/10 px-2 py-1 text-xs text-zinc-400">
-                  $5/mo incl. $5 usage
+                  {formatUsd(estimate.planMinimum)}/mo incl.{' '}
+                  {formatUsd(estimate.planIncludedUsage)} usage
                 </span>
               </div>
             </div>
@@ -410,7 +431,8 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
             <p className="text-muted-foreground mt-5 border-t border-white/10 pt-5 text-sm leading-6">
               Assumes {inputs.averageVcpu.toFixed(2)} average vCPU,{' '}
               {inputs.averageRamGb.toFixed(2)}GB average RAM, {inputs.volumeGb}
-              GB volume, and {inputs.egressGb}GB egress.
+              GB volume, and {inputs.egressGb}GB egress.{' '}
+              {estimate.validationResult.message}
             </p>
           </article>
         </div>
@@ -420,7 +442,9 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
             <p className="text-muted-foreground text-sm">Monthly difference</p>
             <div className="mt-2 flex flex-wrap items-end gap-x-3 gap-y-1">
               <p className="text-4xl font-semibold tabular-nums">
-                {formatUsd(difference.amount)}
+                {estimate.validationResult.valid
+                  ? formatUsd(difference.amount)
+                  : '—'}
               </p>
               <p className="pb-1 text-sm font-medium text-zinc-200">
                 {lowerCostName}
@@ -573,8 +597,8 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
           <div className="text-muted-foreground text-sm leading-6">
             <p className="font-mono text-xs [overflow-wrap:anywhere] break-words whitespace-normal text-zinc-300">
               max(
-              {formatUsd(RAILWAY_RATE_CARD.hobbyMonthlySubscription)}{' '}
-              subscription, {inputs.averageVcpu.toFixed(2)} vCPU ×{' '}
+              {formatUsd(estimate.planMinimum)} {railwayPlan.name} subscription,{' '}
+              {inputs.averageVcpu.toFixed(2)} vCPU ×{' '}
               {formatUsd(RAILWAY_RATE_CARD.cpuPerVcpuMonth)} +{' '}
               {inputs.averageRamGb.toFixed(2)}GB RAM ×{' '}
               {formatUsd(RAILWAY_RATE_CARD.ramPerGbMonth)} + {inputs.volumeGb}GB
@@ -585,15 +609,16 @@ export function RailwayCostCalculator({ lang }: RailwayCostCalculatorProps) {
             <p className="mt-3">
               CPU {formatUsd(estimate.cpu)} · RAM {formatUsd(estimate.ram)} ·
               Volume {formatUsd(estimate.volume)} · Egress{' '}
-              {formatUsd(estimate.egress)}. Estimate verified on{' '}
+              {formatUsd(estimate.egress)} · Usage subtotal{' '}
+              {formatUsd(estimate.usageSubtotal)} · Billed total{' '}
+              {formatUsd(estimate.billedTotal)}. Estimate verified on{' '}
               {RAILWAY_RATE_CARD.verifiedAt}.
             </p>
             <p className="mt-3">
-              This calculator applies Railway Hobby’s{' '}
-              {formatUsd(RAILWAY_RATE_CARD.hobbyMonthlySubscription)}/month
-              subscription and {formatUsd(RAILWAY_RATE_CARD.hobbyIncludedUsage)}{' '}
-              of included usage. Some workloads may require another Railway plan
-              because plan limits vary.
+              {estimate.validationResult.message} Railway {railwayPlan.name}{' '}
+              applies a {formatUsd(estimate.planMinimum)}/month subscription and{' '}
+              {formatUsd(estimate.planIncludedUsage)} of included usage.
+              Measured usage above that minimum becomes the billed total.
             </p>
             <p className="mt-2">
               Sealos plan capacities use Gi. Railway publishes RAM and volume

--- a/app/[lang]/(home)/pricing/config/railway-cost.ts
+++ b/app/[lang]/(home)/pricing/config/railway-cost.ts
@@ -278,12 +278,14 @@ export const calculateBreakEvenUtilization = ({
 
   if (fullComputeCost === 0) return null;
 
+  const baselineCost = Math.max(planMinimum, fixedUsageCost);
+  if (sealosMonthlyPrice <= baselineCost) return 0;
+
   return Math.max(
     0,
     Math.min(
       100,
-      ((sealosMonthlyPrice - planMinimum - fixedUsageCost) / fullComputeCost) *
-        100,
+      ((sealosMonthlyPrice - fixedUsageCost) / fullComputeCost) * 100,
     ),
   );
 };

--- a/app/[lang]/(home)/pricing/config/railway-cost.ts
+++ b/app/[lang]/(home)/pricing/config/railway-cost.ts
@@ -1,14 +1,66 @@
+export type RailwayPlanId = 'hobby' | 'pro';
+export type RailwayPlanSelection = RailwayPlanId | 'auto';
+
+export interface RailwayPlanLimits {
+  maxCpuVcpu: number;
+  maxRamGb: number;
+  maxVolumeGb: number;
+}
+
+export interface RailwayPlan {
+  id: RailwayPlanId;
+  name: string;
+  monthlySubscription: number;
+  includedUsage: number;
+  limits: RailwayPlanLimits;
+  sourceUrl: string;
+}
+
+const RAILWAY_PLANS_SOURCE_URL = 'https://docs.railway.com/pricing/plans';
+
+export const RAILWAY_PLANS: Record<RailwayPlanId, RailwayPlan> = {
+  hobby: {
+    id: 'hobby',
+    name: 'Hobby',
+    monthlySubscription: 5,
+    includedUsage: 5,
+    limits: {
+      maxCpuVcpu: 48,
+      maxRamGb: 48,
+      maxVolumeGb: 5,
+    },
+    sourceUrl: RAILWAY_PLANS_SOURCE_URL,
+  },
+  pro: {
+    id: 'pro',
+    name: 'Pro',
+    monthlySubscription: 20,
+    includedUsage: 20,
+    limits: {
+      maxCpuVcpu: 1000,
+      maxRamGb: 1024,
+      maxVolumeGb: 1024,
+    },
+    sourceUrl: RAILWAY_PLANS_SOURCE_URL,
+  },
+};
+
 export const RAILWAY_RATE_CARD = {
-  hobbyMonthlySubscription: 5,
-  hobbyIncludedUsage: 5,
+  plans: RAILWAY_PLANS,
+  hobbyMonthlySubscription: RAILWAY_PLANS.hobby.monthlySubscription,
+  hobbyIncludedUsage: RAILWAY_PLANS.hobby.includedUsage,
+  proMonthlySubscription: RAILWAY_PLANS.pro.monthlySubscription,
+  proIncludedUsage: RAILWAY_PLANS.pro.includedUsage,
   cpuPerVcpuMonth: 20,
   ramPerGbMonth: 10,
   volumePerGbMonth: 0.15,
   egressPerGb: 0.05,
-  sourceUrl: 'https://docs.railway.com/pricing/plans',
+  sourceUrl: RAILWAY_PLANS_SOURCE_URL,
+  volumeSourceUrl: 'https://docs.railway.com/volumes/reference',
   faqUrl: 'https://docs.railway.com/pricing/faqs',
   costControlUrl: 'https://docs.railway.com/pricing/cost-control',
-  verifiedAt: '2026-07-28',
+  deploymentSourceUrl: 'https://docs.railway.com/guides',
+  verifiedAt: '2026-08-21',
 } as const;
 
 export const DEFAULT_RAILWAY_UTILIZATION = 50;
@@ -20,43 +72,184 @@ export interface RailwayCostInput {
   egressGb: number;
 }
 
+export type RailwayResourceKey = 'averageVcpu' | 'averageRamGb' | 'volumeGb';
+
+export interface RailwayResourceFailure {
+  resource: RailwayResourceKey;
+  value: number;
+  limit: number;
+}
+
+export interface RailwayResourceEligibility {
+  eligible: boolean;
+  failures: RailwayResourceFailure[];
+}
+
+export type RailwayValidationStatus = 'valid' | 'requires-plan' | 'unsupported';
+
+export interface RailwayValidationResult {
+  valid: boolean;
+  status: RailwayValidationStatus;
+  message: string;
+  requiredPlan: RailwayPlanId | null;
+}
+
 export interface RailwayCostEstimate {
+  selectedPlan: RailwayPlanId;
+  requiredPlan: RailwayPlanId | null;
+  planMinimum: number;
+  planIncludedUsage: number;
+  resourceEligibility: RailwayResourceEligibility;
+  validationResult: RailwayValidationResult;
   cpu: number;
   ram: number;
   volume: number;
   egress: number;
   usageSubtotal: number;
+  billedTotal: number;
   total: number;
   minimumApplied: boolean;
 }
+
+const railwayPlanOrder: RailwayPlanId[] = ['hobby', 'pro'];
 
 const clampToZero = (value: number) => Math.max(0, value);
 
 const roundCurrency = (value: number) => Math.round(value * 100) / 100;
 
+const getResourceEligibility = (
+  input: RailwayCostInput,
+  plan: RailwayPlan,
+): RailwayResourceEligibility => {
+  const checks: Array<[RailwayResourceKey, number, number]> = [
+    ['averageVcpu', clampToZero(input.averageVcpu), plan.limits.maxCpuVcpu],
+    ['averageRamGb', clampToZero(input.averageRamGb), plan.limits.maxRamGb],
+    ['volumeGb', clampToZero(input.volumeGb), plan.limits.maxVolumeGb],
+  ];
+  const failures = checks.reduce<RailwayResourceFailure[]>(
+    (result, [resource, value, limit]) => {
+      if (value > limit) result.push({ resource, value, limit });
+      return result;
+    },
+    [],
+  );
+
+  return { eligible: failures.length === 0, failures };
+};
+
+const findEligiblePlan = (
+  input: RailwayCostInput,
+  startAfter: RailwayPlanId,
+): RailwayPlanId | null => {
+  const startIndex = railwayPlanOrder.indexOf(startAfter) + 1;
+  return (
+    railwayPlanOrder
+      .slice(startIndex)
+      .find(
+        (planId) =>
+          getResourceEligibility(input, RAILWAY_PLANS[planId]).eligible,
+      ) ?? null
+  );
+};
+
+const resourceLabels: Record<RailwayResourceKey, string> = {
+  averageVcpu: 'average CPU',
+  averageRamGb: 'average RAM',
+  volumeGb: 'volume',
+};
+
+const formatResourceLimit = (resource: RailwayResourceKey, limit: number) =>
+  `${limit} ${resource === 'averageVcpu' ? 'vCPU' : 'GB'}`;
+
+const resolvePlan = (
+  input: RailwayCostInput,
+  selection: RailwayPlanSelection,
+) => {
+  const hobbyEligibility = getResourceEligibility(input, RAILWAY_PLANS.hobby);
+  const selectedPlanId =
+    selection === 'auto'
+      ? hobbyEligibility.eligible
+        ? 'hobby'
+        : 'pro'
+      : selection;
+  const selectedPlan = RAILWAY_PLANS[selectedPlanId];
+  const resourceEligibility = getResourceEligibility(input, selectedPlan);
+  const requiredPlanFailures =
+    selectedPlanId === 'hobby'
+      ? resourceEligibility.failures
+      : hobbyEligibility.failures;
+  const requirementPlanName =
+    selectedPlanId === 'hobby' ? selectedPlan.name : RAILWAY_PLANS.hobby.name;
+  const requiredPlan = resourceEligibility.eligible
+    ? selection === 'auto' && selectedPlanId !== 'hobby'
+      ? selectedPlanId
+      : null
+    : findEligiblePlan(input, selectedPlanId);
+  const requirementReason = requiredPlanFailures.length
+    ? `because Railway ${requirementPlanName}'s ${requiredPlanFailures
+        .map(
+          ({ resource, limit }) =>
+            `${resourceLabels[resource]} limit is ${formatResourceLimit(resource, limit)}`,
+        )
+        .join(' and ')}`
+    : 'for this workload';
+
+  let status: RailwayValidationStatus = 'valid';
+  let message = `Railway ${selectedPlan.name} supports this workload.`;
+  if (!resourceEligibility.eligible) {
+    status = requiredPlan ? 'requires-plan' : 'unsupported';
+    message = requiredPlan
+      ? `Railway ${RAILWAY_PLANS[requiredPlan].name} is required ${requirementReason}.`
+      : `This workload exceeds Railway ${selectedPlan.name} resource limits.`;
+  } else if (requiredPlan) {
+    message = `Railway ${selectedPlan.name} is required ${requirementReason}.`;
+  }
+
+  return {
+    selectedPlan,
+    requiredPlan,
+    resourceEligibility,
+    validationResult: {
+      valid: resourceEligibility.eligible,
+      status,
+      message,
+      requiredPlan,
+    },
+  };
+};
+
 export const estimateRailwayMonthlyCost = (
   input: RailwayCostInput,
+  selection: RailwayPlanSelection = 'auto',
 ): RailwayCostEstimate => {
+  const { selectedPlan, requiredPlan, resourceEligibility, validationResult } =
+    resolvePlan(input, selection);
   const cpu =
     clampToZero(input.averageVcpu) * RAILWAY_RATE_CARD.cpuPerVcpuMonth;
   const ram = clampToZero(input.averageRamGb) * RAILWAY_RATE_CARD.ramPerGbMonth;
   const volume =
     clampToZero(input.volumeGb) * RAILWAY_RATE_CARD.volumePerGbMonth;
   const egress = clampToZero(input.egressGb) * RAILWAY_RATE_CARD.egressPerGb;
-  const usageSubtotal = cpu + ram + volume + egress;
-  const total = Math.max(
-    RAILWAY_RATE_CARD.hobbyMonthlySubscription,
-    usageSubtotal,
+  const usageSubtotal = roundCurrency(cpu + ram + volume + egress);
+  const billedTotal = roundCurrency(
+    Math.max(selectedPlan.monthlySubscription, usageSubtotal),
   );
 
   return {
+    selectedPlan: selectedPlan.id,
+    requiredPlan,
+    planMinimum: selectedPlan.monthlySubscription,
+    planIncludedUsage: selectedPlan.includedUsage,
+    resourceEligibility,
+    validationResult,
     cpu: roundCurrency(cpu),
     ram: roundCurrency(ram),
     volume: roundCurrency(volume),
     egress: roundCurrency(egress),
-    usageSubtotal: roundCurrency(usageSubtotal),
-    total: roundCurrency(total),
-    minimumApplied: usageSubtotal < RAILWAY_RATE_CARD.hobbyMonthlySubscription,
+    usageSubtotal,
+    billedTotal,
+    total: billedTotal,
+    minimumApplied: usageSubtotal < selectedPlan.monthlySubscription,
   };
 };
 
@@ -66,12 +259,14 @@ export const calculateBreakEvenUtilization = ({
   ram,
   volume,
   egress,
+  railwayPlan = 'hobby',
 }: {
   sealosMonthlyPrice: number;
   cpu: number;
   ram: number;
   volume: number;
   egress: number;
+  railwayPlan?: RailwayPlanId;
 }): number | null => {
   const fixedUsageCost =
     clampToZero(volume) * RAILWAY_RATE_CARD.volumePerGbMonth +
@@ -79,6 +274,7 @@ export const calculateBreakEvenUtilization = ({
   const fullComputeCost =
     clampToZero(cpu) * RAILWAY_RATE_CARD.cpuPerVcpuMonth +
     clampToZero(ram) * RAILWAY_RATE_CARD.ramPerGbMonth;
+  const planMinimum = RAILWAY_PLANS[railwayPlan].monthlySubscription;
 
   if (fullComputeCost === 0) return null;
 
@@ -86,7 +282,8 @@ export const calculateBreakEvenUtilization = ({
     0,
     Math.min(
       100,
-      ((sealosMonthlyPrice - fixedUsageCost) / fullComputeCost) * 100,
+      ((sealosMonthlyPrice - planMinimum - fixedUsageCost) / fullComputeCost) *
+        100,
     ),
   );
 };

--- a/app/[lang]/(home)/pricing/page.tsx
+++ b/app/[lang]/(home)/pricing/page.tsx
@@ -16,6 +16,7 @@ import HeroLinesImage from './assets/hero-lines.svg';
 import { mainPricingPlans, railwayComparablePlans } from './config/plans';
 import {
   DEFAULT_RAILWAY_UTILIZATION,
+  RAILWAY_RATE_CARD,
   calculateCostDifference,
   estimateRailwayMonthlyCost,
   formatUsd,
@@ -45,6 +46,8 @@ const heroRailwayEstimate = estimateRailwayMonthlyCost({
   volumeGb: heroPlan.resources.disk,
   egressGb: heroPlan.resources.traffic,
 });
+const heroRailwayPlan =
+  RAILWAY_RATE_CARD.plans[heroRailwayEstimate.selectedPlan];
 const heroDifference = calculateCostDifference(
   heroPlan.monthlyPrice,
   heroRailwayEstimate.total,
@@ -117,9 +120,11 @@ export default async function PricingPage({ params }: PageProps) {
             />
             <div className="flex items-start justify-between gap-4">
               <div>
-                <p className="text-sm font-medium">Hobby workload example</p>
+                <p className="text-sm font-medium">
+                  Hobby workload example · Railway {heroRailwayPlan.name}
+                </p>
                 <p className="text-muted-foreground mt-1 text-xs">
-                  Same workload inputs, different billing models
+                  {heroRailwayEstimate.validationResult.message}
                 </p>
               </div>
               <span className="max-w-48 border border-white/10 bg-white/5 px-2 py-1 text-right text-xs leading-5 text-zinc-300">
@@ -151,9 +156,13 @@ export default async function PricingPage({ params }: PageProps) {
                     <Image src={RailwayIcon} alt="" width={24} height={24} />
                   </span>
                   <div>
-                    <p className="text-sm font-medium">Railway</p>
+                    <p className="text-sm font-medium">
+                      Railway {heroRailwayPlan.name}
+                    </p>
                     <p className="text-muted-foreground mt-0.5 text-xs">
-                      Usage estimate
+                      {formatUsd(heroRailwayEstimate.planMinimum)} minimum ·{' '}
+                      {formatUsd(heroRailwayEstimate.planIncludedUsage)}{' '}
+                      included
                     </p>
                   </div>
                 </div>

--- a/app/[lang]/(home)/railway-alternative/page.tsx
+++ b/app/[lang]/(home)/railway-alternative/page.tsx
@@ -1,0 +1,534 @@
+import type { Metadata } from 'next';
+import { RailwayAlternativeCtas } from './railway-alternative-ctas';
+import { RailwayHeroDemo } from './railway-hero-demo';
+import styles from './railway-alternative.module.css';
+import { generatePageMetadata } from '@/lib/utils/metadata';
+import { StructuredDataComponent } from '@/components/structured-data';
+import { generateBreadcrumbSchema } from '@/lib/utils/structured-data';
+import { siteConfig } from '@/config/site';
+import { getLanguageSlug } from '@/lib/i18n';
+import {
+  RAILWAY_RATE_CARD,
+  estimateRailwayMonthlyCost,
+  formatUsd,
+  type RailwayCostInput,
+} from '../pricing/config/railway-cost';
+import { railwayComparablePlans } from '../pricing/config/plans';
+
+interface RailwayAlternativePageProps {
+  params: Promise<{ lang: string }>;
+}
+
+const standardPlan = railwayComparablePlans.find(
+  ({ planId }) => planId === 'standard',
+)!;
+
+const standardRailwayInput: RailwayCostInput = {
+  averageVcpu: 4,
+  averageRamGb: 8,
+  volumeGb: 50,
+  egressGb: 300,
+};
+
+const standardRailwayEstimate =
+  estimateRailwayMonthlyCost(standardRailwayInput);
+const standardRailwayPlan =
+  RAILWAY_RATE_CARD.plans[standardRailwayEstimate.selectedPlan];
+
+const standardEstimateIsValid =
+  standardRailwayEstimate.selectedPlan === 'pro' &&
+  standardRailwayEstimate.requiredPlan === 'pro' &&
+  standardRailwayEstimate.validationResult.valid &&
+  standardRailwayEstimate.resourceEligibility.eligible &&
+  standardRailwayEstimate.usageSubtotal === 182.5 &&
+  standardRailwayEstimate.usageSubtotal ===
+    standardRailwayEstimate.billedTotal &&
+  !standardRailwayEstimate.minimumApplied;
+
+const comparisonRows = [
+  {
+    dimension: 'Billing model',
+    sealos: 'Fixed monthly resource packages',
+    railway:
+      'Usage rates with plan minimums and included usage defined by plan',
+  },
+  {
+    dimension: 'Deployment workflow',
+    sealos: 'GitHub repository, Docker image, and guided product deployment',
+    railway:
+      'Mature Git-to-URL workflow with repository, image, and template entry points',
+  },
+  {
+    dimension: 'Workload organization',
+    sealos: 'Apps, workers, databases, and storage in one workspace',
+    railway: 'Services, databases, and volumes grouped in a project',
+  },
+  {
+    dimension: 'Infrastructure path',
+    sealos: 'Managed workflow with Kubernetes-native controls available',
+    railway: 'Managed PaaS abstraction focused on operational simplicity',
+  },
+  {
+    dimension: 'Strongest fit',
+    sealos:
+      'Always-on applications, multi-service systems, and predictable resource budgets',
+    railway:
+      'Lightweight or variable workloads, rapid Git deployments, and usage-based budgets',
+  },
+];
+
+const migrationSteps = [
+  'Deploy the application from its GitHub repository or existing Docker image.',
+  'Copy environment variables and secrets into the target workspace.',
+  'Provision the required database and persistent or object storage.',
+  'Export and import application data with a workload-specific maintenance window.',
+  'Verify internal connections, health checks, logs, and public behavior.',
+  'Point the domain to Sealos after the verification gate passes.',
+];
+
+const createFaqs = (pricingPath: string) => [
+  {
+    question: 'When can Sealos cost less than Railway?',
+    answer: (
+      <>
+        The documented Standard example estimates{' '}
+        {formatUsd(standardPlan.monthlyPrice)} on Sealos and{' '}
+        {standardEstimateIsValid
+          ? formatUsd(standardRailwayEstimate.billedTotal)
+          : 'the current shared Railway estimate'}{' '}
+        on Railway at 50% average compute utilization, 50 GB of volume, and 300
+        GB of egress. Visitors can enter their own usage in the{' '}
+        <a href={pricingPath} className="underline underline-offset-4">
+          linked calculator
+        </a>
+        .
+      </>
+    ),
+  },
+  {
+    question: 'Can I deploy a GitHub repository on Sealos?',
+    answer: (
+      <>
+        Yes. The page CTA opens the current guided product flow with a GitHub
+        deployment task, including the existing authentication and attribution
+        handoff.
+      </>
+    ),
+  },
+  {
+    question: 'Can I move a Railway database and persistent data?',
+    answer: (
+      <>
+        Yes. Provision the destination, export and import with the
+        database-specific guide, verify application connections, and schedule
+        domain cutover after the data gate passes.
+      </>
+    ),
+  },
+  {
+    question: 'Which platform fits lightweight or variable workloads?',
+    answer: (
+      <>
+        Railway is a strong fit for intermittent services, rapid Git-to-URL
+        deployment, and teams that prefer measured usage billing. Sealos is a
+        strong fit for always-on stacks and defined monthly resource packages.
+      </>
+    ),
+  },
+];
+
+export async function generateMetadata({
+  params,
+}: RailwayAlternativePageProps): Promise<Metadata> {
+  const { lang } = await params;
+  const metadata = generatePageMetadata({
+    title: 'Railway Alternative for Always-On Apps',
+    description:
+      'Run always-on apps, databases, workers, and storage with fixed monthly resource packages. Compare Sealos and Railway, then deploy from GitHub.',
+    pathname: '/railway-alternative',
+    lang,
+    languageAlternates: false,
+  });
+
+  if (lang !== 'en') {
+    metadata.robots = {
+      index: false,
+      follow: true,
+      googleBot: {
+        index: false,
+        follow: true,
+      },
+    };
+  }
+
+  return metadata;
+}
+
+export default async function RailwayAlternativePage({
+  params,
+}: RailwayAlternativePageProps) {
+  const { lang } = await params;
+  const comparisonPath = `${getLanguageSlug(lang)}/comparison/sealos-vs-railway/`;
+  const pricingPath = `${getLanguageSlug(lang)}/pricing/#railway-cost`;
+  const breadcrumbSchema =
+    lang === 'en'
+      ? generateBreadcrumbSchema([
+          { name: 'Home', url: `${siteConfig.url.base}/` },
+          {
+            name: 'Railway Alternative',
+            url: `${siteConfig.url.base}/railway-alternative/`,
+          },
+        ])
+      : null;
+
+  return (
+    <main className={styles.page}>
+      {breadcrumbSchema ? (
+        <StructuredDataComponent data={breadcrumbSchema} />
+      ) : null}
+
+      <section
+        data-railway-alternative-section="hero"
+        className={`${styles.section} ${styles.hero}`}
+      >
+        <div className={`container-compact ${styles.heroGrid}`}>
+          <div className={styles.heroCopy}>
+            <h1 className={styles.title}>
+              A Railway alternative with fixed monthly resource packages.
+            </h1>
+            <p className={styles.lede}>
+              Run applications, databases, workers, and storage in one
+              workspace. Start from GitHub and keep a Kubernetes control path
+              available as your system grows.
+            </p>
+            <div className={styles.heroActions}>
+              <RailwayAlternativeCtas lang={lang} placement="hero" />
+            </div>
+            <p className={`${styles.body} ${styles.positioning}`}>
+              Sealos fits always-on applications and multi-service stacks where
+              predictable monthly resources matter. Railway fits lightweight or
+              variable workloads, mature Git-to-URL workflows, and teams that
+              prefer usage billing.
+            </p>
+          </div>
+
+          <RailwayHeroDemo />
+        </div>
+      </section>
+
+      <section
+        data-railway-alternative-section="reasons"
+        className={`container-compact ${styles.section}`}
+      >
+        <div className={styles.sectionHead}>
+          <h2 className={styles.sectionTitle}>
+            Three reasons to choose Sealos
+          </h2>
+        </div>
+        <div className={styles.reasons}>
+          {[
+            {
+              title: 'Predictable monthly resources.',
+              body: 'Sealos packages a defined amount of CPU, memory, disk, and traffic into a monthly plan. This supports budgeting for continuously running workloads.',
+              href: `${getLanguageSlug(lang)}/pricing/`,
+              label: 'See Sealos pricing packages',
+            },
+            {
+              title: 'A full stack in one workspace.',
+              body: 'Applications, workers, databases, persistent storage, and object storage can share one operational workspace.',
+              href: `${getLanguageSlug(lang)}/products/databases/`,
+              label: 'Explore managed databases',
+            },
+            {
+              title: 'A Kubernetes control path.',
+              body: 'Teams can begin with the managed product experience and retain access to Kubernetes-native controls for deeper scheduling, networking, and policy needs.',
+              href: 'https://github.com/labring/sealos',
+              label: 'View the open-source project',
+            },
+          ].map((reason) => (
+            <article key={reason.title} className={styles.reason}>
+              <h3 className={styles.cardTitle}>{reason.title}</h3>
+              <p className={styles.body}>{reason.body}</p>
+              <a
+                href={reason.href}
+                target={reason.href.startsWith('http') ? '_blank' : undefined}
+                rel={reason.href.startsWith('http') ? 'noreferrer' : undefined}
+                className={styles.reasonLink}
+              >
+                {reason.label}
+              </a>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section
+        id="cost-example"
+        data-railway-alternative-section="cost-example"
+        className={`${styles.section} ${styles.costBand}`}
+      >
+        <div className="container-compact">
+          <div className={styles.costHead}>
+            <div className={styles.sectionHead}>
+              <h2 className={styles.sectionTitle}>
+                Transparent Standard cost example
+              </h2>
+              <p className={styles.body}>
+                This normalized workload uses 50% average compute utilization.
+                Sealos Traffic and Railway outbound egress remain different
+                billing concepts; the displayed values carry the same numeric
+                workload input without a unit conversion.
+              </p>
+            </div>
+            <div>
+              <RailwayAlternativeCtas lang={lang} placement="cost_example" />
+            </div>
+          </div>
+
+          <div className={styles.costCards}>
+            <article className={`${styles.costCard} ${styles.costCardSignal}`}>
+              <p className={styles.proofLabel}>Sealos {standardPlan.name}</p>
+              <p className={styles.price}>
+                {formatUsd(standardPlan.monthlyPrice)}
+                <span className={styles.priceLabel}>monthly plan price</span>
+              </p>
+              <ul className={styles.resourceList}>
+                <li>{standardPlan.resources.cpu} vCPU included</li>
+                <li>{standardPlan.resources.ram} GiB memory included</li>
+                <li>{standardPlan.resources.disk} GiB persistent volume</li>
+                <li>{standardPlan.resources.traffic} GB traffic</li>
+              </ul>
+            </article>
+
+            <article className={styles.costCard}>
+              <div className={styles.costTop}>
+                <div>
+                  <p className={styles.proofLabel}>
+                    Railway{' '}
+                    {
+                      RAILWAY_RATE_CARD.plans[
+                        standardRailwayEstimate.selectedPlan
+                      ].name
+                    }{' '}
+                    estimate
+                  </p>
+                  <p className={styles.rateNote}>
+                    {standardRailwayEstimate.validationResult.message}
+                  </p>
+                </div>
+                <span className={styles.status}>
+                  {standardEstimateIsValid ? 'Validated' : 'Recalculate'}
+                </span>
+              </div>
+              <div className={styles.costRows}>
+                {[
+                  {
+                    label: 'CPU',
+                    input: '4 average vCPU',
+                    rate: `${formatUsd(RAILWAY_RATE_CARD.cpuPerVcpuMonth)} / vCPU-month`,
+                    amount: standardRailwayEstimate.cpu,
+                  },
+                  {
+                    label: 'Memory',
+                    input: '8 average GB',
+                    rate: `${formatUsd(RAILWAY_RATE_CARD.ramPerGbMonth)} / GB-month`,
+                    amount: standardRailwayEstimate.ram,
+                  },
+                  {
+                    label: 'Volume',
+                    input: '50 GB',
+                    rate: `${formatUsd(RAILWAY_RATE_CARD.volumePerGbMonth)} / GB-month`,
+                    amount: standardRailwayEstimate.volume,
+                  },
+                  {
+                    label: 'Egress',
+                    input: '300 GB',
+                    rate: `${formatUsd(RAILWAY_RATE_CARD.egressPerGb)} / GB`,
+                    amount: standardRailwayEstimate.egress,
+                  },
+                ].map((row) => (
+                  <div key={row.label} className={styles.costRow}>
+                    <div>
+                      <p>{row.label}</p>
+                      <p className={styles.rateNote}>
+                        {row.input} · {row.rate}
+                      </p>
+                    </div>
+                    <span>{formatUsd(row.amount)}</span>
+                  </div>
+                ))}
+              </div>
+              <div className={styles.costTotal}>
+                <div>
+                  <p className={styles.rateNote}>
+                    Usage subtotal ·{' '}
+                    {formatUsd(standardRailwayEstimate.usageSubtotal)}
+                  </p>
+                  <p className={styles.rateNote}>
+                    {standardRailwayPlan.name} minimum ·{' '}
+                    {formatUsd(standardRailwayEstimate.planMinimum)}
+                  </p>
+                </div>
+                <p className={styles.price}>
+                  {standardEstimateIsValid
+                    ? formatUsd(standardRailwayEstimate.billedTotal)
+                    : 'See calculator'}
+                  <span className={styles.priceLabel}>
+                    estimated monthly cost
+                  </span>
+                </p>
+              </div>
+              <p className={`${styles.rateNote} ${styles.body}`}>
+                Rates and plan metadata verified {RAILWAY_RATE_CARD.verifiedAt}.
+                The 50 GB volume requires Railway {standardRailwayPlan.name};
+                the usage subtotal exceeds the {standardRailwayPlan.name}{' '}
+                minimum for this profile.
+              </p>
+              <div className={styles.costLinks}>
+                <a
+                  href={RAILWAY_RATE_CARD.sourceUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={styles.costLink}
+                >
+                  Railway plan and rate sources
+                </a>
+                <a
+                  href={RAILWAY_RATE_CARD.costControlUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={styles.costLink}
+                >
+                  Railway cost controls
+                </a>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section
+        data-railway-alternative-section="comparison"
+        className={`container-compact ${styles.section}`}
+      >
+        <div className={styles.comparisonHead}>
+          <div className={styles.sectionHead}>
+            <h2 className={styles.sectionTitle}>
+              Choose the operating model that fits your workload.
+            </h2>
+          </div>
+          <a href={comparisonPath} className={styles.textLink}>
+            Read the full comparison
+            <span aria-hidden="true" className={styles.inlineIcon}>
+              →
+            </span>
+          </a>
+        </div>
+        <table className={styles.comparisonTable}>
+          <thead>
+            <tr>
+              <th scope="col">Dimension</th>
+              <th scope="col">Sealos</th>
+              <th scope="col">Railway</th>
+            </tr>
+          </thead>
+          <tbody>
+            {comparisonRows.map((row) => (
+              <tr key={row.dimension}>
+                <th scope="row">{row.dimension}</th>
+                <td data-label="Sealos">{row.sealos}</td>
+                <td data-label="Railway">{row.railway}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section
+        data-railway-alternative-section="migration"
+        className={`${styles.section} ${styles.migration}`}
+      >
+        <div className={`container-compact ${styles.migrationGrid}`}>
+          <div>
+            <h2 className={styles.sectionTitle}>
+              Move one verified workload at a time.
+            </h2>
+            <p className={styles.body}>
+              Use a manual migration path with a workload-specific data gate and
+              cutover check.
+            </p>
+            <div className={styles.heroActions}>
+              <RailwayAlternativeCtas lang={lang} placement="migration" />
+            </div>
+          </div>
+          <ol className={styles.steps}>
+            {migrationSteps.map((step) => (
+              <li key={step} className={styles.step}>
+                <span>{step}</span>
+              </li>
+            ))}
+          </ol>
+          <div className={styles.guides}>
+            <h3 className={styles.guideTitle}>Maintained guides</h3>
+            <div className={styles.guideList}>
+              {[
+                ['Create an app', '/docs/guides/app-deploy/create-app/'],
+                [
+                  'Configure environments',
+                  '/docs/guides/app-deploy/environments/',
+                ],
+                [
+                  'Migrate a database',
+                  '/docs/guides/databases/database-migration-guide/',
+                ],
+                ['Add a domain', '/docs/guides/app-deploy/add-a-domain/'],
+              ].map(([label, path]) => (
+                <a
+                  key={path}
+                  href={`${getLanguageSlug(lang)}${path}`}
+                  className={styles.textLink}
+                >
+                  {label}
+                </a>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section
+        data-railway-alternative-section="faq"
+        className={`container-compact ${styles.section}`}
+      >
+        <div className={styles.sectionHead}>
+          <h2 className={styles.sectionTitle}>
+            Evaluate the move with practical answers.
+          </h2>
+        </div>
+        <div className={styles.faqList}>
+          {createFaqs(pricingPath).map((faq) => (
+            <details key={faq.question} className={styles.faq}>
+              <summary className={styles.faqSummary}>
+                <span>{faq.question}</span>
+                <span aria-hidden="true" className={styles.faqIndicator}>
+                  +
+                </span>
+              </summary>
+              <div className={styles.faqAnswer}>{faq.answer}</div>
+            </details>
+          ))}
+        </div>
+        <div className={styles.finalCta}>
+          <h2 className={styles.sectionTitle}>
+            Run your always-on stack on Sealos.
+          </h2>
+          <p className={styles.body}>
+            Start with a GitHub repository and keep the deployment path open as
+            your workload grows.
+          </p>
+          <RailwayAlternativeCtas lang={lang} placement="final_cta" />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/[lang]/(home)/railway-alternative/railway-alternative-ctas.tsx
+++ b/app/[lang]/(home)/railway-alternative/railway-alternative-ctas.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { ArrowRight } from 'lucide-react';
+import { useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { useGTM } from '@/hooks/use-gtm';
+import { useAuthRedirect } from '@/hooks/use-auth-redirect';
+import { getRybbitCtaProps } from '@/lib/analytics/rybbit-cta';
+import { getOpenBrainParam } from '@/lib/utils/brain';
+import { getLanguageSlug } from '@/lib/i18n';
+import styles from './railway-alternative.module.css';
+
+type RailwayAlternativeCta = {
+  id:
+    | 'railway_alt_hero_deploy_github'
+    | 'railway_alt_cost_compare'
+    | 'railway_alt_migration_deploy_image'
+    | 'railway_alt_final_deploy_github';
+  label: string;
+  location: 'hero' | 'cost_example' | 'migration' | 'final_cta';
+  destination: 'sealos_open_app' | '/pricing/#railway-cost';
+  deployIntent: 'github_repo' | 'docker_image' | 'unselected';
+};
+
+type RailwayAlternativeCtaPlacement =
+  | 'hero'
+  | 'cost_example'
+  | 'migration'
+  | 'final_cta';
+
+const ctas: Record<RailwayAlternativeCta['id'], RailwayAlternativeCta> = {
+  railway_alt_hero_deploy_github: {
+    id: 'railway_alt_hero_deploy_github',
+    label: 'Deploy a GitHub repo',
+    location: 'hero',
+    destination: 'sealos_open_app',
+    deployIntent: 'github_repo',
+  },
+  railway_alt_cost_compare: {
+    id: 'railway_alt_cost_compare',
+    label: 'Compare your cost',
+    location: 'cost_example',
+    destination: '/pricing/#railway-cost',
+    deployIntent: 'unselected',
+  },
+  railway_alt_migration_deploy_image: {
+    id: 'railway_alt_migration_deploy_image',
+    label: 'Deploy your existing image',
+    location: 'migration',
+    destination: 'sealos_open_app',
+    deployIntent: 'docker_image',
+  },
+  railway_alt_final_deploy_github: {
+    id: 'railway_alt_final_deploy_github',
+    label: 'Deploy a GitHub repo',
+    location: 'final_cta',
+    destination: 'sealos_open_app',
+    deployIntent: 'github_repo',
+  },
+};
+
+export function RailwayAlternativeCtas({
+  lang,
+  placement,
+}: {
+  lang: string;
+  placement: RailwayAlternativeCtaPlacement;
+}) {
+  const redirect = useAuthRedirect();
+  const { trackCustom } = useGTM();
+
+  const activate = useCallback(
+    (cta: RailwayAlternativeCta) => {
+      trackCustom('railway_alt_cta_clicked', {
+        cta_id: cta.id,
+        location: cta.location,
+        destination: cta.destination,
+        deploy_intent: cta.deployIntent,
+      });
+    },
+    [trackCustom],
+  );
+
+  const handleDeploy = useCallback(
+    (cta: RailwayAlternativeCta) => {
+      activate(cta);
+      const openapp =
+        cta.deployIntent === 'docker_image'
+          ? getOpenBrainParam('Deploy my existing Docker image')
+          : getOpenBrainParam('Deploy my GitHub repository');
+      void redirect({ openapp });
+    },
+    [activate, redirect],
+  );
+
+  const cta =
+    ctas[
+      placement === 'hero'
+        ? 'railway_alt_hero_deploy_github'
+        : placement === 'cost_example'
+          ? 'railway_alt_cost_compare'
+          : placement === 'migration'
+            ? 'railway_alt_migration_deploy_image'
+            : 'railway_alt_final_deploy_github'
+    ];
+
+  if (placement === 'cost_example') {
+    return (
+      <a
+        href={`${getLanguageSlug(lang)}/pricing/#railway-cost`}
+        onClick={() => activate(cta)}
+        className={styles.costCta}
+        {...getRybbitCtaProps(cta)}
+      >
+        {cta.label}
+        <ArrowRight aria-hidden="true" className={styles.inlineIcon} />
+      </a>
+    );
+  }
+
+  return (
+    <div className={styles.deployGroup}>
+      <Button
+        variant="outline"
+        className={styles.deployButton}
+        onClick={() => handleDeploy(cta)}
+        {...getRybbitCtaProps(cta)}
+      >
+        {cta.label}
+        <ArrowRight aria-hidden="true" className={styles.inlineIcon} />
+      </Button>
+      {placement === 'hero' ? (
+        <a
+          href={`${getLanguageSlug(lang)}/railway-alternative/#cost-example`}
+          className={styles.heroCostLink}
+        >
+          Compare costs
+        </a>
+      ) : null}
+    </div>
+  );
+}

--- a/app/[lang]/(home)/railway-alternative/railway-alternative.module.css
+++ b/app/[lang]/(home)/railway-alternative/railway-alternative.module.css
@@ -1,0 +1,785 @@
+/* Hallmark · genre: modern-minimal · macrostructure: Split Studio · tone: technical-austere · anchor hue: cobalt
+ * theme: adapted dark Cobalt · enrichment: E4 Floating no-frame · nav: N5 Floating pill · footer: Ft5 Statement
+ * contrast: pass (40–41) · slop: pass (42–49) · mobile: pass (34, 49, 50–57)
+ */
+/* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5 */
+.page {
+  background: var(--color-railway-paper);
+  color: var(--color-railway-ink);
+  font-family: var(--font-railway-body);
+}
+
+:global(body):has(.page) :global(nav:has([role='banner'])) {
+  background: var(--color-railway-graphite);
+  color: var(--color-railway-ink);
+}
+
+.section {
+  padding-block: var(--space-railway-16);
+}
+
+.proofLabel {
+  color: var(--color-railway-cobalt);
+  font-size: var(--text-railway-sm);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.title,
+.sectionTitle,
+.cardTitle {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-family: var(--font-railway-display);
+  font-weight: 600;
+  letter-spacing: -0.045em;
+}
+
+.title {
+  margin: 0;
+  font-size: var(--text-railway-display);
+  line-height: 0.98;
+}
+
+.sectionTitle {
+  margin: 0;
+  max-width: 22ch;
+  font-size: var(--text-railway-2xl);
+  line-height: 1.03;
+}
+
+.cardTitle {
+  font-size: var(--text-railway-xl);
+  line-height: 1.2;
+}
+
+.lede,
+.body,
+.muted,
+.rateNote {
+  color: var(--color-railway-ink-muted);
+}
+
+.lede {
+  margin-top: var(--space-railway-6);
+  max-width: 60ch;
+  font-size: var(--text-railway-lg);
+  line-height: 1.55;
+}
+
+.body {
+  margin-top: var(--space-railway-5);
+  font-size: var(--text-railway-base);
+  line-height: 1.65;
+}
+
+.hero {
+  border-bottom: var(--rule-railway-hairline);
+  padding-block-start: var(--space-railway-12);
+  padding-block-end: var(--space-railway-16);
+}
+
+.heroGrid,
+.migrationGrid {
+  display: grid;
+  gap: var(--space-railway-12);
+  min-width: 0;
+}
+
+.heroGrid {
+  align-items: start;
+}
+
+.heroCopy {
+  max-width: 54rem;
+}
+
+.heroActions {
+  margin-top: var(--space-railway-8);
+}
+
+.positioning {
+  margin-top: var(--space-railway-10);
+  max-width: 65ch;
+  border-top: var(--rule-railway-hairline);
+  padding-top: var(--space-railway-4);
+}
+
+.heroDemo {
+  position: relative;
+  min-width: 0;
+}
+
+.demoPoster {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  aspect-ratio: 1312 / 812;
+  min-width: 0;
+  overflow: hidden;
+  border: var(--rule-railway-hairline);
+  border-radius: var(--radius-railway-card);
+  background: var(--color-railway-surface);
+}
+
+.demoPosterBar,
+.demoPosterBody,
+.demoControls {
+  display: flex;
+  align-items: center;
+}
+
+.demoPosterBar {
+  justify-content: space-between;
+  border-bottom: var(--rule-railway-hairline);
+  padding: var(--space-railway-3) var(--space-railway-4);
+  color: var(--color-railway-ink-muted);
+  font-size: var(--text-railway-xs);
+  font-weight: 600;
+}
+
+.demoPosterStatus {
+  display: inline-flex;
+  gap: var(--space-railway-2);
+  align-items: center;
+  color: var(--color-railway-cobalt);
+}
+
+.demoPosterStatus::before {
+  width: var(--space-railway-2);
+  height: var(--space-railway-2);
+  border-radius: 50%;
+  background: currentColor;
+  content: '';
+}
+
+.demoPosterBody {
+  flex-wrap: wrap;
+  gap: var(--space-railway-4);
+  align-content: center;
+  padding: var(--space-railway-6);
+}
+
+.demoPosterMark {
+  display: grid;
+  flex: 0 0 auto;
+  width: var(--space-railway-10);
+  height: var(--space-railway-10);
+  place-items: center;
+  border: var(--rule-railway-hairline);
+  border-radius: var(--radius-railway-card);
+  color: var(--color-railway-cobalt);
+  font-size: var(--text-railway-xs);
+  font-weight: 600;
+}
+
+.demoPosterBody strong,
+.demoPosterBody small {
+  display: block;
+}
+
+.demoPosterBody strong {
+  font-size: var(--text-railway-sm);
+}
+
+.demoPosterBody small,
+.demoPosterUrl {
+  margin-top: var(--space-railway-1);
+  color: var(--color-railway-ink-muted);
+  font-size: var(--text-railway-xs);
+}
+
+.demoPosterUrl {
+  min-width: 0;
+  margin-left: auto;
+  overflow-wrap: anywhere;
+}
+
+.demoControls {
+  gap: var(--space-railway-2);
+  justify-content: flex-end;
+  margin-top: var(--space-railway-3);
+}
+
+.demoControl {
+  min-width: 4.5rem;
+  min-height: 2.75rem;
+  border: var(--rule-railway-hairline);
+  border-radius: var(--radius-railway-tight);
+  background: var(--color-railway-surface);
+  color: var(--color-railway-ink);
+  padding-inline: var(--space-railway-4);
+  font-size: var(--text-railway-sm);
+  font-weight: 600;
+}
+
+.demoControl:focus-visible {
+  outline: 2px solid var(--color-railway-focus);
+  outline-offset: var(--space-railway-3xs);
+}
+
+.demoControl:active {
+  opacity: 0.72;
+}
+
+.demoControl:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.mobileDemoSteps {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-railway-2);
+  margin-top: var(--space-railway-3);
+  list-style: none;
+}
+
+.mobileDemoSteps li {
+  border-top: var(--rule-railway-hairline);
+  padding-top: var(--space-railway-3);
+  color: var(--color-railway-ink-muted);
+  font-size: var(--text-railway-xs);
+  font-weight: 600;
+  text-align: center;
+}
+
+.sectionHead,
+.costHead,
+.comparisonHead {
+  min-width: 0;
+}
+
+.reasons {
+  display: grid;
+  gap: var(--space-railway-1);
+  margin-top: var(--space-railway-10);
+  border-top: var(--rule-railway-hairline);
+}
+
+.reason {
+  display: grid;
+  gap: var(--space-railway-4);
+  min-width: 0;
+  border-bottom: var(--rule-railway-hairline);
+  padding-block: var(--space-railway-6);
+}
+
+.reason .body {
+  margin-top: 0;
+}
+
+.reasonLink,
+.textLink,
+.costLink {
+  display: inline-flex;
+  gap: var(--space-railway-2);
+  align-items: center;
+  width: fit-content;
+  min-height: 2.75rem;
+  color: var(--color-railway-cobalt);
+  font-size: var(--text-railway-sm);
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-color: var(--color-railway-link-rule);
+  text-underline-offset: var(--space-railway-3xs);
+  white-space: nowrap;
+}
+
+.reasonLink:focus-visible,
+.textLink:focus-visible,
+.costLink:focus-visible,
+.faqSummary:focus-visible {
+  border-radius: var(--radius-railway-tight);
+  outline: 2px solid var(--color-railway-focus);
+  outline-offset: var(--space-railway-3xs);
+}
+
+.costBand {
+  background: var(--color-railway-surface);
+  color: var(--color-railway-ink);
+}
+
+.costBand .proofLabel,
+.costBand .costCta,
+.costBand .costLink {
+  color: var(--color-railway-cobalt-inverse);
+  text-decoration-color: var(--color-railway-link-rule-inverse);
+}
+
+.costBand .muted,
+.costBand .body,
+.costBand .rateNote {
+  color: var(--color-railway-ink-light);
+}
+
+.costBand .costCta:focus-visible,
+.costBand .costLink:focus-visible {
+  outline-color: var(--color-railway-focus-inverse);
+}
+
+.costHead,
+.comparisonHead {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-railway-6);
+}
+
+.costCards {
+  display: grid;
+  gap: var(--space-railway-6);
+  margin-top: var(--space-railway-10);
+}
+
+.costCard {
+  min-width: 0;
+  border: var(--rule-railway-inverse);
+  border-radius: var(--radius-railway-card);
+  padding: var(--space-railway-6);
+}
+
+.costCardSignal {
+  border-color: var(--color-railway-cobalt);
+  background: var(--color-railway-surface-raised);
+  color: var(--color-railway-ink);
+}
+
+.price {
+  margin-top: var(--space-railway-3);
+  font-family: var(--font-railway-display);
+  font-size: var(--text-railway-2xl);
+  font-weight: 600;
+  letter-spacing: -0.04em;
+}
+
+.priceLabel {
+  margin-left: var(--space-railway-2);
+  color: var(--color-railway-ink-light);
+  font-family: var(--font-railway-body);
+  font-size: var(--text-railway-sm);
+  font-weight: 400;
+  letter-spacing: 0;
+}
+
+.resourceList,
+.guideList,
+.costLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-railway-3) var(--space-railway-5);
+  margin-top: var(--space-railway-6);
+  font-size: var(--text-railway-sm);
+}
+
+.resourceList {
+  display: grid;
+  gap: var(--space-railway-3);
+  list-style: none;
+}
+
+.costTop,
+.costTotal,
+.costRow {
+  display: flex;
+  gap: var(--space-railway-4);
+  justify-content: space-between;
+}
+
+.costTop {
+  align-items: flex-start;
+}
+
+.status {
+  flex: 0 0 auto;
+  border: var(--rule-railway-inverse);
+  border-radius: var(--radius-railway-tight);
+  padding: var(--space-railway-1) var(--space-railway-2);
+  color: var(--color-railway-ink-light);
+  font-size: var(--text-railway-xs);
+}
+
+.costRows {
+  margin-top: var(--space-railway-6);
+  border-block: var(--rule-railway-inverse);
+}
+
+.costRow {
+  align-items: center;
+  padding-block: var(--space-railway-4);
+}
+
+.costRow + .costRow {
+  border-top: var(--rule-railway-inverse);
+}
+
+.rateNote {
+  margin-top: var(--space-railway-1);
+  font-size: var(--text-railway-xs);
+}
+
+.costTotal {
+  align-items: end;
+  margin-top: var(--space-railway-6);
+}
+
+.comparisonTable {
+  width: 100%;
+  margin-top: var(--space-railway-10);
+  border: var(--rule-railway-hairline);
+  border-collapse: collapse;
+  border-radius: var(--radius-railway-card);
+  font-size: var(--text-railway-sm);
+  text-align: left;
+}
+
+.comparisonTable th,
+.comparisonTable td {
+  min-width: 0;
+  border-top: var(--rule-railway-hairline);
+  padding: var(--space-railway-5);
+  vertical-align: top;
+}
+
+.comparisonTable thead th {
+  border-top: 0;
+  color: var(--color-railway-ink-muted);
+  font-weight: 600;
+}
+
+.comparisonTable tbody th {
+  color: var(--color-railway-ink);
+  font-weight: 600;
+}
+
+.comparisonTable td:first-of-type {
+  color: var(--color-railway-cobalt);
+}
+
+.comparisonTable td:last-child {
+  color: var(--color-railway-ink-muted);
+}
+
+.migration {
+  border-block: var(--rule-railway-hairline);
+  padding-block-start: var(--space-railway-20);
+  padding-block-end: var(--space-railway-16);
+}
+
+.steps {
+  display: grid;
+  gap: var(--space-railway-3);
+  list-style: none;
+  counter-reset: step;
+}
+
+.step {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-railway-4);
+  align-items: start;
+  min-width: 0;
+  border-top: var(--rule-railway-hairline);
+  padding-top: var(--space-railway-4);
+  line-height: 1.6;
+}
+
+.step::before {
+  color: var(--color-railway-cobalt);
+  content: counter(step, decimal-leading-zero);
+  counter-increment: step;
+  font-size: var(--text-railway-sm);
+  font-weight: 600;
+}
+
+.guideTitle {
+  color: var(--color-railway-cobalt);
+  font-size: var(--text-railway-sm);
+  font-weight: 600;
+}
+
+.faqList {
+  margin-top: var(--space-railway-10);
+  border-block: var(--rule-railway-hairline);
+}
+
+.faq {
+  border-top: var(--rule-railway-hairline);
+  padding-block: var(--space-railway-5);
+}
+
+.faq:first-child {
+  border-top: 0;
+}
+
+.faqSummary {
+  display: flex;
+  gap: var(--space-railway-4);
+  align-items: center;
+  justify-content: space-between;
+  min-width: 0;
+  min-height: 2.75rem;
+  cursor: pointer;
+  font-family: var(--font-railway-display);
+  font-size: var(--text-railway-lg);
+  font-weight: 600;
+  line-height: 1.3;
+  list-style: none;
+}
+
+.faqSummary > :first-child {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.faqSummary::-webkit-details-marker {
+  display: none;
+}
+
+.faqIndicator {
+  flex: 0 0 auto;
+  color: var(--color-railway-cobalt);
+  transition: transform var(--duration-railway-disclosure)
+    var(--ease-railway-out);
+}
+
+.faq[open] .faqIndicator {
+  transform: rotate(45deg);
+}
+
+.faqAnswer {
+  max-width: 65ch;
+  padding-top: var(--space-railway-4);
+  color: var(--color-railway-ink-muted);
+  font-size: var(--text-railway-sm);
+  line-height: 1.7;
+}
+
+.finalCta {
+  display: grid;
+  gap: var(--space-railway-5);
+  margin-top: var(--space-railway-16);
+  border-top: var(--rule-railway-hairline);
+  padding-top: var(--space-railway-8);
+}
+
+.finalCta .body {
+  margin-top: 0;
+}
+
+.deployGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-railway-4);
+  align-items: center;
+}
+
+.deployButton {
+  display: inline-flex;
+  gap: var(--space-railway-2);
+  align-items: center;
+  height: 2.75rem;
+  border: 1px solid var(--color-railway-cobalt);
+  border-radius: var(--radius-railway-tight);
+  background: var(--color-railway-cobalt);
+  color: var(--color-railway-cobalt-ink);
+  padding-inline: var(--space-railway-5);
+  transition:
+    transform var(--duration-railway-press) var(--ease-railway-out),
+    background-color var(--duration-railway-press) var(--ease-railway-out);
+  white-space: nowrap;
+}
+
+.deployButton:focus-visible {
+  outline: 2px solid var(--color-railway-focus);
+  outline-offset: var(--space-railway-3xs);
+}
+
+.deployButton:active {
+  transform: translateY(1px);
+}
+
+.deployButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.costCta,
+.heroCostLink {
+  display: inline-flex;
+  gap: var(--space-railway-2);
+  align-items: center;
+  min-height: 2.75rem;
+  color: var(--color-railway-cobalt);
+  font-size: var(--text-railway-sm);
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-color: var(--color-railway-link-rule);
+  text-underline-offset: var(--space-railway-3xs);
+  white-space: nowrap;
+}
+
+.inlineIcon {
+  width: var(--space-railway-4);
+  height: var(--space-railway-4);
+}
+
+.costCta:focus-visible,
+.heroCostLink:focus-visible {
+  border-radius: var(--radius-railway-tight);
+  outline: 2px solid var(--color-railway-focus);
+  outline-offset: var(--space-railway-3xs);
+}
+
+.reasonLink:active,
+.textLink:active,
+.costLink:active,
+.costCta:active,
+.heroCostLink:active,
+.faqSummary:active {
+  opacity: 0.72;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .reasonLink:hover,
+  .textLink:hover,
+  .costLink:hover,
+  .costCta:hover,
+  .heroCostLink:hover {
+    text-decoration-thickness: 2px;
+  }
+
+  .faqSummary:hover {
+    color: var(--color-railway-cobalt-hover);
+  }
+
+  .deployButton:hover {
+    background: var(--color-railway-cobalt-hover);
+    color: var(--color-railway-cobalt-ink);
+  }
+
+  .demoControl:hover {
+    border-color: var(--color-railway-cobalt);
+    color: var(--color-railway-cobalt-hover);
+  }
+}
+
+@media (min-width: 48rem) {
+  .section {
+    padding-block: var(--space-railway-24);
+  }
+
+  .hero {
+    padding-block-start: var(--space-railway-16);
+    padding-block-end: var(--space-railway-24);
+  }
+
+  .mobileDemoSteps {
+    display: none;
+  }
+
+  .reason {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.5fr) auto;
+    align-items: start;
+  }
+
+  .costHead,
+  .comparisonHead {
+    flex-direction: row;
+    align-items: end;
+    justify-content: space-between;
+  }
+
+  .costCards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .migrationGrid {
+    grid-template-columns: minmax(0, 5fr) minmax(0, 7fr);
+  }
+
+  .migration {
+    padding-block-start: calc(var(--space-railway-24) + var(--space-railway-4));
+    padding-block-end: var(--space-railway-24);
+  }
+
+  .guides {
+    grid-column: 2;
+  }
+
+  .finalCta {
+    grid-template-columns: minmax(0, 6fr) minmax(18rem, 4fr);
+    column-gap: var(--space-railway-12);
+    align-items: start;
+  }
+
+  .finalCta .sectionTitle {
+    grid-row: span 2;
+  }
+}
+
+@media (max-width: 47.99rem) {
+  .demoPosterUrl {
+    flex-basis: 100%;
+    margin-left: 0;
+  }
+
+  .comparisonTable,
+  .comparisonTable tbody,
+  .comparisonTable tr,
+  .comparisonTable th,
+  .comparisonTable td {
+    display: block;
+  }
+
+  .comparisonTable thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  .comparisonTable {
+    border: 0;
+  }
+
+  .comparisonTable tr {
+    border: var(--rule-railway-hairline);
+    border-radius: var(--radius-railway-card);
+  }
+
+  .comparisonTable tr + tr {
+    margin-top: var(--space-railway-4);
+  }
+
+  .comparisonTable th,
+  .comparisonTable td {
+    border-top: var(--rule-railway-hairline);
+    padding: var(--space-railway-4);
+  }
+
+  .comparisonTable tbody th {
+    border-top: 0;
+  }
+
+  .comparisonTable td::before {
+    display: block;
+    margin-bottom: var(--space-railway-1);
+    color: var(--color-railway-ink-muted);
+    content: attr(data-label);
+    font-size: var(--text-railway-xs);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .demoControl,
+  .deployButton,
+  .faqIndicator {
+    transition-duration: 0ms;
+  }
+}

--- a/app/[lang]/(home)/railway-alternative/railway-hero-demo.tsx
+++ b/app/[lang]/(home)/railway-alternative/railway-hero-demo.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import styles from './railway-alternative.module.css';
+
+const GitHubImportDemo = dynamic(
+  () =>
+    import('../(new-home)/components/deploy-demos/github-import-demo').then(
+      (module) => module.GitHubImportDemo,
+    ),
+  {
+    loading: () => <RailwayHeroPoster />,
+    ssr: false,
+  },
+);
+
+export function RailwayHeroDemo() {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [desktop, setDesktop] = useState(false);
+  const [entered, setEntered] = useState(false);
+  const [finished, setFinished] = useState(false);
+  const [paused, setPaused] = useState(false);
+  const [reducedMotion, setReducedMotion] = useState(false);
+  const [runId, setRunId] = useState(0);
+
+  useEffect(() => {
+    const desktopQuery = window.matchMedia('(min-width: 48rem)');
+    const reducedMotionQuery = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    );
+    const syncPreferences = () => {
+      setDesktop(desktopQuery.matches);
+      setReducedMotion(reducedMotionQuery.matches);
+    };
+
+    syncPreferences();
+    desktopQuery.addEventListener('change', syncPreferences);
+    reducedMotionQuery.addEventListener('change', syncPreferences);
+
+    return () => {
+      desktopQuery.removeEventListener('change', syncPreferences);
+      reducedMotionQuery.removeEventListener('change', syncPreferences);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!desktop || entered || reducedMotion) return;
+
+    const root = rootRef.current;
+    if (!root || !('IntersectionObserver' in window)) {
+      setEntered(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) return;
+
+        setEntered(true);
+        observer.disconnect();
+      },
+      { rootMargin: '120px 0px', threshold: 0.15 },
+    );
+
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, [desktop, entered, reducedMotion]);
+
+  const handleComplete = useCallback(() => {
+    setFinished(true);
+    setPaused(true);
+  }, []);
+
+  const replay = () => {
+    setFinished(false);
+    setPaused(false);
+    setRunId((current) => current + 1);
+  };
+
+  const showAnimation = desktop && entered && !reducedMotion;
+
+  return (
+    <div
+      ref={rootRef}
+      className={styles.heroDemo}
+      data-railway-hero-demo
+      data-railway-hero-demo-mode={showAnimation ? 'animated' : 'static'}
+    >
+      <p className="sr-only">
+        GitHub repository deployment progresses from import to a live public
+        address.
+      </p>
+
+      {showAnimation ? (
+        <GitHubImportDemo
+          key={runId}
+          active
+          loop={false}
+          onComplete={handleComplete}
+          paused={paused}
+          variant="compact"
+        />
+      ) : (
+        <RailwayHeroPoster />
+      )}
+
+      {showAnimation ? (
+        <div className={styles.demoControls}>
+          <button
+            type="button"
+            className={styles.demoControl}
+            disabled={finished}
+            onClick={() => setPaused((current) => !current)}
+          >
+            {paused ? 'Play' : 'Pause'}
+          </button>
+          <button type="button" className={styles.demoControl} onClick={replay}>
+            Replay
+          </button>
+        </div>
+      ) : null}
+
+      <ol
+        className={styles.mobileDemoSteps}
+        aria-label="GitHub deployment steps"
+      >
+        {['Import', 'Deploy', 'Live'].map((step) => (
+          <li key={step}>{step}</li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+function RailwayHeroPoster() {
+  return (
+    <div className={styles.demoPoster} data-railway-hero-poster aria-hidden>
+      <div className={styles.demoPosterBar}>
+        <span>GitHub deployment</span>
+        <span className={styles.demoPosterStatus}>Live</span>
+      </div>
+      <div className={styles.demoPosterBody}>
+        <span className={styles.demoPosterMark}>GH</span>
+        <span>
+          <strong>sealos/demo-api</strong>
+          <small>Deployment ready</small>
+        </span>
+        <span className={styles.demoPosterUrl}>demo-api.sealos.run</span>
+      </div>
+    </div>
+  );
+}

--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -93,7 +93,7 @@ export default async function LocaleLayout({
 
         <Analytics />
       </head>
-      <body className="bg-background flex min-h-screen max-w-[100vw] flex-col overflow-x-hidden">
+      <body className="bg-background flex min-h-screen max-w-[100vw] flex-col overflow-x-clip">
         <GTMBody />
         <HomepageDarkMode />
         <AuthFormProvider>

--- a/app/[lang]/utils/is-forced-dark-mode.ts
+++ b/app/[lang]/utils/is-forced-dark-mode.ts
@@ -10,6 +10,10 @@ export function isForcedDarkMode(pathname: string): boolean {
       match: 'full',
     },
     {
+      path: '/railway-alternative',
+      match: 'prefix',
+    },
+    {
       path: '/brain-caps-preview',
       match: 'full',
     },

--- a/app/global.css
+++ b/app/global.css
@@ -1,3 +1,4 @@
+@import '../tokens.css';
 @import 'tailwindcss';
 @import 'fumadocs-ui/css/neutral.css';
 @import 'fumadocs-ui/css/preset.css';

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -60,6 +60,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...AGENT_GUIDES.map((agent) => agent.path),
   ].map((path) => toSitemapItem(getUrl, path, 'monthly', 0.75));
 
+  const railwayAlternativePages: MetadataRoute.Sitemap = isZhCn
+    ? []
+    : [toSitemapItem(getUrl, '/railway-alternative', 'monthly', 0.8)];
+
   const appStorePages: MetadataRoute.Sitemap = appsConfig.map((app) =>
     toSitemapItem(getUrl, getAppDetailPathname(app.slug), 'weekly', 0.7),
   );
@@ -89,6 +93,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     toSitemapItem(getUrl, '/', 'monthly', 1),
     ...staticProductPages,
     ...staticMarketingPages,
+    ...railwayAlternativePages,
     ...appStorePages,
     ...chineseSpecificPages,
     toSitemapItem(getUrl, '/docs', 'monthly', 0.8),

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -16,5 +16,5 @@ export const locales: Array<{ name: string; locale: languagesType }> = [
 ];
 
 export function getLanguageSlug(lang: string) {
-  return lang === i18n.defaultLanguage || lang === 'en' ? '' : `/${lang}`;
+  return lang === i18n.defaultLanguage ? '' : `/${lang}`;
 }

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -16,5 +16,5 @@ export const locales: Array<{ name: string; locale: languagesType }> = [
 ];
 
 export function getLanguageSlug(lang: string) {
-  return lang == i18n.defaultLanguage ? '' : `/${lang}`;
+  return lang === i18n.defaultLanguage || lang === 'en' ? '' : `/${lang}`;
 }

--- a/lib/source.ts
+++ b/lib/source.ts
@@ -31,15 +31,19 @@ export const blog = loader({
   source: createMDXSource(blogPosts, []),
 });
 
+const englishContentI18n = {
+  ...i18n,
+  defaultLanguage: 'en',
+};
 
 export const tutorials = loader({
-  i18n,
+  i18n: englishContentI18n,
   baseUrl: '/tutorials',
   source: createMDXSource(tutorialPosts, []),
 });
 
 export const faqSource = loader({
-  i18n,
+  i18n: englishContentI18n,
   baseUrl: '/ai-quick-reference',
   source: createMDXSource(aiQuickReference, []),
 });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "lint": "rm -f tsconfig.tsbuildinfo && tsc --noEmit",
     "test:pricing": "node --test scripts/railway-cost.test.js",
+    "test:railway-alternative": "node --test scripts/railway-alternative.test.mjs",
     "build": "pnpm verify:ai-faq-index && next build && node scripts/normalize-root-locale.js && pnpm verify:ai-faq-routes",
     "validate-tutorials": "node scripts/validate-tutorials.mjs",
     "build:analyze": "pnpm verify:ai-faq-index && ANALYZE=true next build && node scripts/normalize-root-locale.js && pnpm verify:ai-faq-routes",

--- a/scripts/normalize-root-locale.js
+++ b/scripts/normalize-root-locale.js
@@ -45,6 +45,17 @@ async function main() {
     await fs.cp(src, dest, { recursive: true, force: true });
   }
 
+  if (locale !== 'en') {
+    // AI FAQ content is English-only; keep its canonical English root artifact.
+    const englishFaqDir = path.join(outDir, 'en', 'ai-quick-reference');
+    if (await pathExists(englishFaqDir)) {
+      await fs.cp(englishFaqDir, path.join(outDir, 'ai-quick-reference'), {
+        recursive: true,
+        force: true,
+      });
+    }
+  }
+
   console.log(
     `[normalize-root-locale] copied ${locale}/ content to root export directory.`,
   );

--- a/scripts/railway-alternative.test.mjs
+++ b/scripts/railway-alternative.test.mjs
@@ -1,0 +1,499 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  getRemainingDuration,
+  getNextPlaybackState,
+} from '../app/[lang]/(home)/(new-home)/components/deploy-demos/deploy-demo-playback.mjs';
+
+const root = process.cwd();
+const routeDir = join(root, 'app', '[lang]', '(home)', 'railway-alternative');
+const pageSource = readFileSync(join(routeDir, 'page.tsx'), 'utf8');
+const ctaSource = readFileSync(
+  join(routeDir, 'railway-alternative-ctas.tsx'),
+  'utf8',
+);
+const heroDemoSource = readFileSync(
+  join(routeDir, 'railway-hero-demo.tsx'),
+  'utf8',
+);
+const deployDemoDir = join(
+  root,
+  'app',
+  '[lang]',
+  '(home)',
+  '(new-home)',
+  'components',
+  'deploy-demos',
+);
+const githubDemoSource = readFileSync(
+  join(deployDemoDir, 'github-import-demo.tsx'),
+  'utf8',
+);
+const playbackSource = readFileSync(
+  join(deployDemoDir, 'deploy-demo-common.tsx'),
+  'utf8',
+);
+const deploymentCanvasSource = readFileSync(
+  join(deployDemoDir, 'deployment-canvas.tsx'),
+  'utf8',
+);
+const routeStyles = readFileSync(
+  join(routeDir, 'railway-alternative.module.css'),
+  'utf8',
+);
+const globalStyles = readFileSync(join(root, 'app', 'global.css'), 'utf8');
+const tokenStyles = readFileSync(join(root, 'tokens.css'), 'utf8');
+const localeLayoutSource = readFileSync(
+  join(root, 'app', '[lang]', 'layout.tsx'),
+  'utf8',
+);
+const hallmarkPreflight = JSON.parse(
+  readFileSync(join(root, '.hallmark', 'preflight.json'), 'utf8'),
+);
+const hallmarkLog = JSON.parse(
+  readFileSync(join(root, '.hallmark', 'log.json'), 'utf8'),
+);
+const railwayDocument = readFileSync(
+  join(root, 'docs', 'railway-alternative.md'),
+  'utf8',
+);
+const sitemapSource = readFileSync(join(root, 'app', 'sitemap.ts'), 'utf8');
+const darkModeSource = readFileSync(
+  join(root, 'app', '[lang]', 'utils', 'is-forced-dark-mode.ts'),
+  'utf8',
+);
+const pricingSource = readFileSync(
+  join(
+    root,
+    'app',
+    '[lang]',
+    '(home)',
+    'pricing',
+    'components',
+    'RailwayCostCalculator.tsx',
+  ),
+  'utf8',
+);
+const railwayCostSource = readFileSync(
+  join(root, 'app', '[lang]', '(home)', 'pricing', 'config', 'railway-cost.ts'),
+  'utf8',
+);
+const railwayComparisonSource = readFileSync(
+  join(root, 'app', '[lang]', '(home)', 'comparison', 'config', 'railway.tsx'),
+  'utf8',
+);
+const comparisonFaqSource = readFileSync(
+  join(root, 'app', '[lang]', '(home)', 'comparison', 'config', 'faqs.ts'),
+  'utf8',
+);
+const railwayFaqStart = comparisonFaqSource.indexOf(
+  '// Railway-specific FAQs (default)',
+);
+assert.notEqual(railwayFaqStart, -1);
+const railwayFaqSource = comparisonFaqSource.slice(railwayFaqStart);
+const authRedirectSource = readFileSync(
+  join(root, 'hooks', 'use-auth-redirect.ts'),
+  'utf8',
+);
+const attributionSource = readFileSync(
+  join(root, 'lib', 'attribution-url.ts'),
+  'utf8',
+);
+const packageJson = JSON.parse(
+  readFileSync(join(root, 'package.json'), 'utf8'),
+);
+
+test('route metadata and owned schema follow the locale contract', () => {
+  assert.match(pageSource, /languageAlternates: false/);
+  assert.match(pageSource, /if \(lang !== 'en'\)/);
+  assert.match(pageSource, /index: false/);
+  assert.match(pageSource, /generateBreadcrumbSchema/);
+  assert.match(pageSource, /lang === 'en'/);
+  assert.doesNotMatch(pageSource, /FAQPage/);
+});
+
+test('route inherits the homepage forced-dark mode', () => {
+  assert.match(
+    darkModeSource,
+    /path: '\/railway-alternative',\s*match: 'prefix'/,
+  );
+});
+
+test('page renders the six locked sections and one H1', () => {
+  const sections = [
+    ...pageSource.matchAll(/data-railway-alternative-section="([^"]+)"/g),
+  ].map(([, section]) => section);
+
+  assert.deepEqual(sections, [
+    'hero',
+    'reasons',
+    'cost-example',
+    'comparison',
+    'migration',
+    'faq',
+  ]);
+  assert.equal((pageSource.match(/<h1\b/g) ?? []).length, 1);
+});
+
+test('CTA contracts preserve handoffs and emit one approved event shape', () => {
+  const ctaIds = [
+    'railway_alt_hero_deploy_github',
+    'railway_alt_cost_compare',
+    'railway_alt_migration_deploy_image',
+    'railway_alt_final_deploy_github',
+  ];
+
+  for (const ctaId of ctaIds) assert.match(ctaSource, new RegExp(ctaId));
+  for (const label of [
+    'Deploy a GitHub repo',
+    'Compare your cost',
+    'Deploy your existing image',
+    'Compare costs',
+  ]) {
+    assert.match(ctaSource, new RegExp(label));
+  }
+  for (const location of ['hero', 'cost_example', 'migration', 'final_cta']) {
+    assert.match(ctaSource, new RegExp(`location: '${location}'`));
+  }
+  for (const deployIntent of ['github_repo', 'docker_image', 'unselected']) {
+    assert.match(ctaSource, new RegExp(`deployIntent: '${deployIntent}'`));
+  }
+
+  assert.equal(
+    (ctaSource.match(/trackCustom\('railway_alt_cta_clicked'/g) ?? []).length,
+    1,
+  );
+  for (const field of ['cta_id', 'location', 'destination', 'deploy_intent']) {
+    assert.match(ctaSource, new RegExp(`${field}:`));
+  }
+  assert.doesNotMatch(ctaSource, /email|user_id|identity/);
+  assert.match(ctaSource, /getOpenBrainParam\('Deploy my GitHub repository'\)/);
+  assert.match(
+    ctaSource,
+    /getOpenBrainParam\('Deploy my existing Docker image'\)/,
+  );
+  assert.match(ctaSource, /useAuthRedirect/);
+  assert.match(ctaSource, /getRybbitCtaProps/);
+  assert.match(authRedirectSource, /appendAttributionToUrl/);
+  assert.match(attributionSource, /sea_attr/);
+});
+
+test('Hero reuses the compact GitHub walkthrough with one-shot playback', () => {
+  assert.match(pageSource, /<RailwayHeroDemo \/>/);
+  assert.doesNotMatch(
+    pageSource,
+    /next\/image|figcaption|github-import\.webp|account data/,
+  );
+
+  assert.match(heroDemoSource, /dynamic\(/);
+  assert.match(heroDemoSource, /ssr: false/);
+  assert.match(heroDemoSource, /IntersectionObserver/);
+  assert.match(heroDemoSource, /\(min-width: 48rem\)/);
+  assert.match(heroDemoSource, /prefers-reduced-motion: reduce/);
+  assert.match(heroDemoSource, /loop=\{false\}/);
+  assert.match(heroDemoSource, /paused=\{paused\}/);
+  assert.match(heroDemoSource, /onComplete=\{handleComplete\}/);
+  assert.match(heroDemoSource, /variant="compact"/);
+  assert.match(heroDemoSource, /\['Import', 'Deploy', 'Live'\]/);
+  assert.match(heroDemoSource, /paused \? 'Play' : 'Pause'/);
+  assert.match(heroDemoSource, />\s*Replay\s*</);
+  assert.doesNotMatch(heroDemoSource, /aria-pressed/);
+
+  const compactStart = githubDemoSource.indexOf('const compactGithubSteps');
+  const compactEnd = githubDemoSource.indexOf(
+    'export const githubImportDemoDurationMs',
+  );
+  assert.ok(compactStart > -1 && compactEnd > compactStart);
+  assert.match(githubDemoSource, /variant = 'full'/);
+  assert.match(
+    githubDemoSource,
+    /githubImportDemoDurationMs = githubSteps\.reduce/,
+  );
+  const compactSource = githubDemoSource.slice(compactStart, compactEnd);
+  const compactRawDuration = [
+    ...compactSource.matchAll(/duration: (\d+)/g),
+  ].reduce((total, [, duration]) => total + Number(duration), 0);
+
+  assert.equal(Math.round(compactRawDuration * 0.42), 7350);
+  assert.match(compactSource, /clickTarget: 'repoDeploy'/);
+  assert.match(compactSource, /formClosed: true/);
+  assert.doesNotMatch(
+    compactSource,
+    /clickTarget: 'authorize'|activeField: 'secret'|clickTarget: 'secretSubmit'/,
+  );
+
+  assert.match(playbackSource, /loop = true/);
+  assert.match(playbackSource, /paused = false/);
+  assert.match(playbackSource, /onComplete\?\.\(\)/);
+  assert.match(playbackSource, /completionNotifiedRef/);
+  assert.match(playbackSource, /getRemainingDuration/);
+  assert.match(playbackSource, /getNextPlaybackState/);
+  assert.match(playbackSource, /DEMO_STEP_DURATION_SCALE = 0\.42/);
+  assert.match(
+    githubDemoSource,
+    /variant === 'compact' && readyStage === 15[\s\S]*\? 'Running'/,
+  );
+  assert.match(
+    deploymentCanvasSource,
+    /runtimeStatus \?\? config\.runtimeStatus \?\? 'Creating'/,
+  );
+});
+
+test('shared playback calculations retain progress and completion semantics', () => {
+  assert.equal(getRemainingDuration(1_000, 0.4), 600);
+
+  assert.deepEqual(
+    getNextPlaybackState({ index: 2, loop: false, stepCount: 3 }),
+    { completed: true, index: 2, progress: 1 },
+  );
+
+  assert.deepEqual(
+    getNextPlaybackState({ index: 2, loop: true, stepCount: 3 }),
+    { completed: false, index: 0, progress: 0 },
+  );
+});
+
+test('durable measurement contract matches the approved Issue 333 authority', () => {
+  assert.match(railwayDocument, /approved_with_release_gates/);
+  assert.match(
+    railwayDocument,
+    /`build_started`, `deploy_success`, and\s+`running_24h`/,
+  );
+  for (const field of [
+    'deployment_id',
+    'workspace_id',
+    'consent_provenance.subject_id',
+    'first_touch.landing_hostname',
+    'first_touch.landing_path',
+    'seven 24-hour days',
+  ]) {
+    assert.match(railwayDocument, new RegExp(field.replaceAll('.', '\\.')));
+  }
+  assert.match(
+    railwayDocument,
+    /100 denominator visitors and 30\s+attributed build-start users/,
+  );
+  assert.match(
+    railwayDocument,
+    /Build Started v2[\s\S]*Google Ads conversion-action labels/,
+  );
+  assert.match(
+    railwayDocument,
+    /GTM delivery[\s\S]*GLOBAL[\s\S]*running_24h[\s\S]*Issue #335/,
+  );
+  assert.doesNotMatch(
+    railwayDocument,
+    /pre-launch approval is a release-readiness gate/,
+  );
+  assert.match(
+    railwayDocument,
+    /Quick task `260824-fda` owns the Railway\s+Hero redesign/,
+  );
+  assert.match(
+    hallmarkPreflight.motion,
+    /Motion-driven GitHub walkthrough with JavaScript viewport and playback controls/,
+  );
+  assert.doesNotMatch(
+    railwayDocument,
+    /workspace_created|app_or_database_deployed|20% signup-to-activation/,
+  );
+});
+
+test('route includes required links, evidence, and shared pricing consumption', () => {
+  for (const requiredPath of [
+    '/pricing/#railway-cost',
+    '/comparison/sealos-vs-railway/',
+    '/docs/guides/app-deploy/create-app/',
+    '/docs/guides/app-deploy/environments/',
+    '/docs/guides/databases/database-migration-guide/',
+    '/docs/guides/app-deploy/add-a-domain/',
+    'RAILWAY_RATE_CARD.sourceUrl',
+  ]) {
+    assert.match(pageSource, new RegExp(requiredPath.replaceAll('/', '\\/')));
+  }
+
+  assert.match(pageSource, /estimateRailwayMonthlyCost/);
+  assert.match(pageSource, /RAILWAY_RATE_CARD/);
+  assert.match(pageSource, /standardRailwayEstimate\.selectedPlan === 'pro'/);
+  assert.match(pageSource, /standardRailwayEstimate\.usageSubtotal === 182\.5/);
+  assert.doesNotMatch(pageSource, /cpuPerVcpuMonth:\s*20/);
+});
+
+test('connected discovery consumes the route and links back to it', () => {
+  assert.match(sitemapSource, /const railwayAlternativePages/);
+  assert.match(sitemapSource, /isZhCn/);
+  assert.match(sitemapSource, /'\/railway-alternative'/);
+  assert.match(pricingSource, /railway-alternative/);
+  assert.match(pricingSource, /railway_alternative_page/);
+  assert.match(railwayComparisonSource, /railway-alternative/);
+});
+
+test('all evaluation surfaces consume shared Railway evidence and estimates', () => {
+  for (const source of [pageSource, pricingSource, railwayComparisonSource]) {
+    assert.match(source, /RAILWAY_RATE_CARD/);
+    assert.match(source, /estimateRailwayMonthlyCost/);
+    assert.match(source, /RAILWAY_RATE_CARD\.verifiedAt/);
+  }
+
+  for (const field of [
+    'billedTotal',
+    'planMinimum',
+    'resourceEligibility',
+    'validationResult',
+  ]) {
+    assert.match(railwayComparisonSource, new RegExp(`estimate\\.${field}`));
+  }
+  assert.match(railwayComparisonSource, /RAILWAY_RATE_CARD\.plans/);
+  assert.match(
+    railwayComparisonSource,
+    /RAILWAY_RATE_CARD\.deploymentSourceUrl/,
+  );
+  assert.match(railwayCostSource, /RAILWAY_RATE_CARD/);
+  assert.match(railwayCostSource, /verifiedAt: '2026-08-21'/);
+
+  for (const source of [
+    pageSource,
+    pricingSource,
+    railwayComparisonSource,
+    railwayFaqSource,
+  ]) {
+    assert.doesNotMatch(
+      source,
+      /(?:hobby|pro)(?:MonthlySubscription|IncludedUsage|PerVcpuMonth|PerGbMonth|PerGb):\s*\d/i,
+    );
+  }
+});
+
+test('evaluation surfaces expose locale-aware two-way discovery links', () => {
+  assert.match(
+    pricingSource,
+    /getLanguageSlug\(lang\)[\s\S]{0,100}railway-alternative\//,
+  );
+  assert.match(
+    pageSource,
+    /getLanguageSlug\(lang\)[\s\S]{0,100}pricing\/#railway-cost/,
+  );
+  assert.match(
+    ctaSource,
+    /getLanguageSlug\(lang\)[\s\S]{0,100}pricing\/#railway-cost/,
+  );
+  assert.match(railwayComparisonSource, /Ready to migrate or deploy/);
+  assert.match(railwayComparisonSource, /\/railway-alternative\//);
+  assert.match(railwayFaqSource, /\/pricing\/#railway-cost/);
+});
+
+test('Railway comparison copy excludes prohibited stale claims', () => {
+  const sources = [pageSource, railwayComparisonSource, railwayFaqSource];
+  for (const source of sources) {
+    for (const claim of [
+      /always cheaper/i,
+      /save 70%/i,
+      /zero lock-in|never locked in/i,
+      /Hobby:\s*8|Pro:\s*32/i,
+      /Typical migrations complete in/i,
+      /support response/i,
+      /\btestimonial\b|\brating\b|\bbenchmark\b/i,
+      /unlimited team seats/i,
+    ]) {
+      assert.doesNotMatch(source, claim);
+    }
+  }
+});
+
+test('focused contract test remains runnable through package scripts', () => {
+  assert.equal(
+    packageJson.scripts['test:railway-alternative'],
+    'node --test scripts/railway-alternative.test.mjs',
+  );
+  const assetPath = join(
+    root,
+    'public',
+    'images',
+    'railway-alternative',
+    'github-import.webp',
+  );
+  assert.equal(existsSync(assetPath), false);
+});
+
+test('route design contract uses the shared Hallmark token surface', () => {
+  assert.match(
+    pageSource,
+    /import styles from '.\/railway-alternative\.module\.css'/,
+  );
+  assert.match(
+    ctaSource,
+    /import styles from '.\/railway-alternative\.module\.css'/,
+  );
+  assert.match(
+    routeStyles.trimStart(),
+    /^\/\* Hallmark · genre: modern-minimal · macrostructure: Split Studio · tone: technical-austere · anchor hue: cobalt/,
+  );
+  assert.match(routeStyles, /Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5/);
+  assert.equal(
+    (globalStyles.match(/@import '\.\.\/tokens\.css';/g) ?? []).length,
+    1,
+  );
+
+  for (const group of [
+    '--color-railway-',
+    '--font-railway-',
+    '--space-railway-',
+    '--text-railway-',
+    '--ease-railway-',
+    '--duration-railway-',
+    '--rule-railway-',
+    '--radius-railway-',
+  ]) {
+    assert.match(tokenStyles, new RegExp(group));
+  }
+
+  assert.match(
+    tokenStyles.trimStart(),
+    /^\/\* Hallmark · genre: modern-minimal · macrostructure: Split Studio/,
+  );
+  assert.match(tokenStyles, /html,[\s\S]*body[\s\S]*overflow-x: clip/);
+  assert.match(tokenStyles, /--color-railway-surface-raised:/);
+  const [, paperLightness] =
+    tokenStyles.match(/--color-railway-paper: oklch\(([\d.]+)/) ?? [];
+  const [, inkLightness] =
+    tokenStyles.match(/--color-railway-ink: oklch\(([\d.]+)/) ?? [];
+  assert.ok(Number(paperLightness) < 0.2);
+  assert.ok(Number(inkLightness) > 0.9);
+  assert.match(localeLayoutSource, /overflow-x-clip/);
+  assert.match(routeStyles, /minmax\(0, 1fr\)/);
+  assert.match(routeStyles, /overflow-wrap: anywhere/);
+  assert.match(routeStyles, /white-space: nowrap/);
+  assert.match(routeStyles, /prefers-reduced-motion/);
+  assert.match(routeStyles, /var\(--color-railway-/);
+  assert.match(routeStyles, /var\(--font-railway-/);
+  assert.match(
+    routeStyles,
+    /nav:has\(\[role='banner'\]\)[\s\S]{0,100}var\(--color-railway-graphite\)/,
+  );
+  for (const easing of ['out', 'in', 'in-out']) {
+    assert.match(tokenStyles, new RegExp(`--ease-railway-${easing}:`));
+  }
+  assert.doesNotMatch(routeStyles, /color-mix\(/);
+  assert.doesNotMatch(pageSource, /styles\.eyebrow/);
+  assert.doesNotMatch(
+    routeStyles,
+    /transition-all|backdrop-filter|box-shadow|position:\s*fixed/,
+  );
+  assert.doesNotMatch(pageSource, /(?:bg|text|border)-(?:blue|zinc|white)-/);
+  assert.doesNotMatch(ctaSource, /(?:bg|text|border)-(?:blue|zinc|white)-/);
+  assert.equal(hallmarkPreflight.framework, 'Next.js 14 App Router');
+  assert.match(hallmarkPreflight.palette, /dark Cobalt/);
+  assert.match(routeStyles, /theme: adapted dark Cobalt/);
+  assert.ok(
+    hallmarkLog.some(
+      ({ macrostructure, theme, variant, enrichment }) =>
+        macrostructure === 'Split Studio' &&
+        theme === 'Cobalt' &&
+        variant === 'dark' &&
+        enrichment === 'E4 Floating no-frame',
+    ),
+  );
+});

--- a/scripts/railway-alternative.test.mjs
+++ b/scripts/railway-alternative.test.mjs
@@ -50,16 +50,6 @@ const localeLayoutSource = readFileSync(
   join(root, 'app', '[lang]', 'layout.tsx'),
   'utf8',
 );
-const hallmarkPreflight = JSON.parse(
-  readFileSync(join(root, '.hallmark', 'preflight.json'), 'utf8'),
-);
-const hallmarkLog = JSON.parse(
-  readFileSync(join(root, '.hallmark', 'log.json'), 'utf8'),
-);
-const railwayDocument = readFileSync(
-  join(root, 'docs', 'railway-alternative.md'),
-  'utf8',
-);
 const sitemapSource = readFileSync(join(root, 'app', 'sitemap.ts'), 'utf8');
 const darkModeSource = readFileSync(
   join(root, 'app', '[lang]', 'utils', 'is-forced-dark-mode.ts'),
@@ -256,52 +246,6 @@ test('shared playback calculations retain progress and completion semantics', ()
   );
 });
 
-test('durable measurement contract matches the approved Issue 333 authority', () => {
-  assert.match(railwayDocument, /approved_with_release_gates/);
-  assert.match(
-    railwayDocument,
-    /`build_started`, `deploy_success`, and\s+`running_24h`/,
-  );
-  for (const field of [
-    'deployment_id',
-    'workspace_id',
-    'consent_provenance.subject_id',
-    'first_touch.landing_hostname',
-    'first_touch.landing_path',
-    'seven 24-hour days',
-  ]) {
-    assert.match(railwayDocument, new RegExp(field.replaceAll('.', '\\.')));
-  }
-  assert.match(
-    railwayDocument,
-    /100 denominator visitors and 30\s+attributed build-start users/,
-  );
-  assert.match(
-    railwayDocument,
-    /Build Started v2[\s\S]*Google Ads conversion-action labels/,
-  );
-  assert.match(
-    railwayDocument,
-    /GTM delivery[\s\S]*GLOBAL[\s\S]*running_24h[\s\S]*Issue #335/,
-  );
-  assert.doesNotMatch(
-    railwayDocument,
-    /pre-launch approval is a release-readiness gate/,
-  );
-  assert.match(
-    railwayDocument,
-    /Quick task `260824-fda` owns the Railway\s+Hero redesign/,
-  );
-  assert.match(
-    hallmarkPreflight.motion,
-    /Motion-driven GitHub walkthrough with JavaScript viewport and playback controls/,
-  );
-  assert.doesNotMatch(
-    railwayDocument,
-    /workspace_created|app_or_database_deployed|20% signup-to-activation/,
-  );
-});
-
 test('route includes required links, evidence, and shared pricing consumption', () => {
   for (const requiredPath of [
     '/pricing/#railway-cost',
@@ -484,16 +428,5 @@ test('route design contract uses the shared Hallmark token surface', () => {
   );
   assert.doesNotMatch(pageSource, /(?:bg|text|border)-(?:blue|zinc|white)-/);
   assert.doesNotMatch(ctaSource, /(?:bg|text|border)-(?:blue|zinc|white)-/);
-  assert.equal(hallmarkPreflight.framework, 'Next.js 14 App Router');
-  assert.match(hallmarkPreflight.palette, /dark Cobalt/);
   assert.match(routeStyles, /theme: adapted dark Cobalt/);
-  assert.ok(
-    hallmarkLog.some(
-      ({ macrostructure, theme, variant, enrichment }) =>
-        macrostructure === 'Split Studio' &&
-        theme === 'Cobalt' &&
-        variant === 'dark' &&
-        enrichment === 'E4 Floating no-frame',
-    ),
-  );
 });

--- a/scripts/railway-cost.test.js
+++ b/scripts/railway-cost.test.js
@@ -34,10 +34,13 @@ const estimatePlan = ({ cpu, ram, disk, traffic }, utilization) =>
   }).total;
 
 test('uses the verified Railway rate card', () => {
+  assert.equal(RAILWAY_RATE_CARD.verifiedAt, '2026-08-21');
   assert.deepEqual(
     {
       hobbySubscription: RAILWAY_RATE_CARD.hobbyMonthlySubscription,
       hobbyIncludedUsage: RAILWAY_RATE_CARD.hobbyIncludedUsage,
+      proSubscription: RAILWAY_RATE_CARD.proMonthlySubscription,
+      proIncludedUsage: RAILWAY_RATE_CARD.proIncludedUsage,
       cpu: RAILWAY_RATE_CARD.cpuPerVcpuMonth,
       ram: RAILWAY_RATE_CARD.ramPerGbMonth,
       volume: RAILWAY_RATE_CARD.volumePerGbMonth,
@@ -46,11 +49,35 @@ test('uses the verified Railway rate card', () => {
     {
       hobbySubscription: 5,
       hobbyIncludedUsage: 5,
+      proSubscription: 20,
+      proIncludedUsage: 20,
       cpu: 20,
       ram: 10,
       volume: 0.15,
       egress: 0.05,
     },
+  );
+  assert.deepEqual(RAILWAY_RATE_CARD.plans.hobby.limits, {
+    maxCpuVcpu: 48,
+    maxRamGb: 48,
+    maxVolumeGb: 5,
+  });
+  assert.deepEqual(RAILWAY_RATE_CARD.plans.pro.limits, {
+    maxCpuVcpu: 1000,
+    maxRamGb: 1024,
+    maxVolumeGb: 1024,
+  });
+  assert.equal(
+    RAILWAY_RATE_CARD.plans.hobby.sourceUrl,
+    'https://docs.railway.com/pricing/plans',
+  );
+  assert.equal(
+    RAILWAY_RATE_CARD.plans.pro.sourceUrl,
+    'https://docs.railway.com/pricing/plans',
+  );
+  assert.equal(
+    RAILWAY_RATE_CARD.deploymentSourceUrl,
+    'https://docs.railway.com/guides',
   );
   assert.equal(DEFAULT_RAILWAY_UTILIZATION, 50);
 });
@@ -61,7 +88,7 @@ test('estimates Starter at 10%, 25%, 50%, and 100% utilization', () => {
     [0.1, 0.25, 0.5, 1].map((utilization) =>
       estimatePlan(starter, utilization),
     ),
-    [8, 17, 32, 62],
+    [20, 20, 32, 62],
   );
 });
 
@@ -69,19 +96,137 @@ test('estimates Hobby at 10%, 25%, 50%, and 100% utilization', () => {
   const hobby = { cpu: 4, ram: 4, disk: 20, traffic: 50 };
   assert.deepEqual(
     [0.1, 0.25, 0.5, 1].map((utilization) => estimatePlan(hobby, utilization)),
-    [17.5, 35.5, 65.5, 125.5],
+    [20, 35.5, 65.5, 125.5],
   );
 });
 
-test('applies the Railway Hobby subscription minimum', () => {
-  const estimate = estimateRailwayMonthlyCost({
+test('applies the Railway Hobby and Pro subscription minimums', () => {
+  const hobbyEstimate = estimateRailwayMonthlyCost(
+    {
+      averageVcpu: 0,
+      averageRamGb: 0,
+      volumeGb: 0,
+      egressGb: 0,
+    },
+    'hobby',
+  );
+  assert.equal(hobbyEstimate.selectedPlan, 'hobby');
+  assert.equal(hobbyEstimate.planMinimum, 5);
+  assert.equal(hobbyEstimate.planIncludedUsage, 5);
+  assert.equal(hobbyEstimate.billedTotal, 5);
+  assert.equal(hobbyEstimate.minimumApplied, true);
+
+  const proEstimate = estimateRailwayMonthlyCost(
+    {
+      averageVcpu: 0,
+      averageRamGb: 0,
+      volumeGb: 0,
+      egressGb: 0,
+    },
+    'pro',
+  );
+  assert.equal(proEstimate.selectedPlan, 'pro');
+  assert.equal(proEstimate.planMinimum, 20);
+  assert.equal(proEstimate.planIncludedUsage, 20);
+  assert.equal(proEstimate.billedTotal, 20);
+  assert.equal(proEstimate.minimumApplied, true);
+});
+
+test('requires Railway Pro when Hobby cannot hold the workload', () => {
+  const input = {
     averageVcpu: 0,
     averageRamGb: 0,
-    volumeGb: 0,
+    volumeGb: 50,
     egressGb: 0,
+  };
+  const hobbyEstimate = estimateRailwayMonthlyCost(input, 'hobby');
+  assert.equal(hobbyEstimate.selectedPlan, 'hobby');
+  assert.equal(hobbyEstimate.resourceEligibility.eligible, false);
+  assert.deepEqual(hobbyEstimate.resourceEligibility.failures, [
+    { resource: 'volumeGb', value: 50, limit: 5 },
+  ]);
+  assert.equal(hobbyEstimate.requiredPlan, 'pro');
+  assert.equal(hobbyEstimate.validationResult.status, 'requires-plan');
+  assert.equal(hobbyEstimate.validationResult.valid, false);
+  assert.equal(
+    hobbyEstimate.validationResult.message,
+    "Railway Pro is required because Railway Hobby's volume limit is 5 GB.",
+  );
+
+  const automaticEstimate = estimateRailwayMonthlyCost(input);
+  assert.equal(automaticEstimate.selectedPlan, 'pro');
+  assert.equal(automaticEstimate.requiredPlan, 'pro');
+  assert.equal(automaticEstimate.resourceEligibility.eligible, true);
+  assert.equal(automaticEstimate.validationResult.valid, true);
+  assert.equal(
+    automaticEstimate.validationResult.message,
+    "Railway Pro is required because Railway Hobby's volume limit is 5 GB.",
+  );
+});
+
+test('validates CPU and memory limits for each plan', () => {
+  const hobbyEstimate = estimateRailwayMonthlyCost(
+    {
+      averageVcpu: 49,
+      averageRamGb: 49,
+      volumeGb: 0,
+      egressGb: 0,
+    },
+    'hobby',
+  );
+  assert.deepEqual(hobbyEstimate.resourceEligibility.failures, [
+    { resource: 'averageVcpu', value: 49, limit: 48 },
+    { resource: 'averageRamGb', value: 49, limit: 48 },
+  ]);
+  assert.equal(hobbyEstimate.requiredPlan, 'pro');
+
+  const proEstimate = estimateRailwayMonthlyCost(
+    {
+      averageVcpu: 1001,
+      averageRamGb: 1025,
+      volumeGb: 0,
+      egressGb: 0,
+    },
+    'pro',
+  );
+  assert.equal(proEstimate.validationResult.status, 'unsupported');
+  assert.equal(proEstimate.validationResult.valid, false);
+});
+
+test('estimates the Standard comparison profile on Railway Pro', () => {
+  const estimate = estimateRailwayMonthlyCost({
+    averageVcpu: 4,
+    averageRamGb: 8,
+    volumeGb: 50,
+    egressGb: 300,
   });
-  assert.equal(estimate.total, 5);
-  assert.equal(estimate.minimumApplied, true);
+
+  assert.deepEqual(
+    {
+      selectedPlan: estimate.selectedPlan,
+      planMinimum: estimate.planMinimum,
+      cpu: estimate.cpu,
+      ram: estimate.ram,
+      volume: estimate.volume,
+      egress: estimate.egress,
+      usageSubtotal: estimate.usageSubtotal,
+      billedTotal: estimate.billedTotal,
+      total: estimate.total,
+      valid: estimate.validationResult.valid,
+    },
+    {
+      selectedPlan: 'pro',
+      planMinimum: 20,
+      cpu: 80,
+      ram: 80,
+      volume: 7.5,
+      egress: 15,
+      usageSubtotal: 182.5,
+      billedTotal: 182.5,
+      total: 182.5,
+      valid: true,
+    },
+  );
 });
 
 test('reports either platform as the lower-cost result', () => {
@@ -111,7 +256,7 @@ test('calculates the Starter and Hobby cost crossover points', () => {
       volume: 10,
       egress: 10,
     })?.toFixed(1),
-    '8.3',
+    '0.0',
   );
   assert.equal(
     calculateBreakEvenUtilization({
@@ -121,6 +266,6 @@ test('calculates the Starter and Hobby cost crossover points', () => {
       volume: 20,
       egress: 50,
     })?.toFixed(1),
-    '16.3',
+    '12.1',
   );
 });

--- a/scripts/railway-cost.test.js
+++ b/scripts/railway-cost.test.js
@@ -256,7 +256,7 @@ test('calculates the Starter and Hobby cost crossover points', () => {
       volume: 10,
       egress: 10,
     })?.toFixed(1),
-    '0.0',
+    '8.3',
   );
   assert.equal(
     calculateBreakEvenUtilization({
@@ -265,7 +265,18 @@ test('calculates the Starter and Hobby cost crossover points', () => {
       ram: 4,
       volume: 20,
       egress: 50,
-    })?.toFixed(1),
-    '12.1',
+    })?.toFixed(2),
+    '16.25',
+  );
+  assert.equal(
+    calculateBreakEvenUtilization({
+      sealosMonthlyPrice: 10,
+      cpu: 4,
+      ram: 4,
+      volume: 20,
+      egress: 50,
+      railwayPlan: 'pro',
+    }),
+    0,
   );
 });

--- a/tokens.css
+++ b/tokens.css
@@ -1,0 +1,59 @@
+/* Hallmark · genre: modern-minimal · macrostructure: Split Studio · tone: technical-austere · anchor hue: cobalt */
+:root {
+  --color-railway-paper: oklch(0.145 0.018 260);
+  --color-railway-surface: oklch(0.19 0.02 260);
+  --color-railway-surface-raised: oklch(0.23 0.024 260);
+  --color-railway-ink: oklch(0.94 0.008 250);
+  --color-railway-ink-muted: oklch(0.72 0.014 255);
+  --color-railway-ink-light: oklch(0.82 0.012 255);
+  --color-railway-cobalt: oklch(0.72 0.15 255);
+  --color-railway-cobalt-hover: oklch(0.78 0.13 255);
+  --color-railway-cobalt-ink: oklch(0.145 0.018 260);
+  --color-railway-cobalt-inverse: oklch(0.78 0.13 255);
+  --color-railway-focus: oklch(0.82 0.12 255);
+  --color-railway-focus-inverse: oklch(0.91 0.04 250);
+  --color-railway-graphite: oklch(0.17 0.018 260);
+  --color-railway-link-rule: oklch(0.54 0.08 255);
+  --color-railway-link-rule-inverse: oklch(0.62 0.1 255);
+
+  --font-railway-display: 'Geist', Arial, sans-serif;
+  --font-railway-body: 'Geist', Arial, sans-serif;
+
+  --space-railway-3xs: 0.125rem;
+  --space-railway-1: 0.25rem;
+  --space-railway-2: 0.5rem;
+  --space-railway-3: 0.75rem;
+  --space-railway-4: 1rem;
+  --space-railway-5: 1.25rem;
+  --space-railway-6: 1.5rem;
+  --space-railway-8: 2rem;
+  --space-railway-10: 2.5rem;
+  --space-railway-12: 3rem;
+  --space-railway-16: 4rem;
+  --space-railway-20: 5rem;
+  --space-railway-24: 6rem;
+
+  --text-railway-xs: 0.75rem;
+  --text-railway-sm: 0.875rem;
+  --text-railway-base: 1rem;
+  --text-railway-lg: clamp(1.125rem, 1.8vw, 1.25rem);
+  --text-railway-xl: clamp(1.25rem, 2vw, 1.5rem);
+  --text-railway-2xl: clamp(1.75rem, 4vw, 3.25rem);
+  --text-railway-display: clamp(2.25rem, 5vw, 3.75rem);
+
+  --ease-railway-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-railway-in: cubic-bezier(0.7, 0, 0.84, 0);
+  --ease-railway-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+  --duration-railway-press: 120ms;
+  --duration-railway-disclosure: 160ms;
+
+  --rule-railway-hairline: 1px solid oklch(0.29 0.018 260);
+  --rule-railway-inverse: 1px solid oklch(0.36 0.022 260);
+  --radius-railway-tight: 0.25rem;
+  --radius-railway-card: 0.5rem;
+}
+
+html,
+body {
+  overflow-x: clip;
+}


### PR DESCRIPTION
## Summary

- ship the localized Railway Alternative landing page, hero demo, CTAs, SEO wiring, and sitemap entry
- make Railway pricing estimates plan-aware and align comparison FAQs
- preserve dark-mode and dual-locale behavior across the new experience
- record the product analytics contract, attribution boundaries, CTA identifiers, and validation evidence
- fix deployment demo playback and related review findings

## Validation

- `pnpm lint`
- Static and dual-locale validation was run locally

## Issues

Closes #330
Closes #331
Closes #332
Closes #333
Closes #334