### PR TITLE
docs(blog): link Milvus mentions to official site

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -7,8 +7,8 @@ current_phase_name: sitemap-route-parity-and-production-verification
 status: blocked
 stopped_at: Independent Phase 32 verification complete with production acceptance BLOCKED
 last_updated: "2026-08-12T07:22:00Z"
-last_activity: 2026-08-16
-last_activity_desc: Completed quick task 260816-m0b for pnpm-based Codex worktree dependencies
+last_activity: 2026-09-01
+last_activity_desc: Added Milvus homepage links to two specified blog posts
 progress:
   total_phases: 2
   completed_phases: 1
@@ -48,7 +48,7 @@ Phase 32 owns the pending PARITY-02 and DELIVERY-02 requirements.
 Phase: 32 (sitemap-route-parity-and-production-verification) — BLOCKED
 Plan: 4 of 4
 Status: Independent verification complete with 14/16 must-haves; production acceptance BLOCKED
-Last activity: 2026-08-13 — Completed quick task 260813-gu4 for the centered Sealos Skills Hero
+Last activity: 2026-09-01 - Completed quick task 260901-kum: Add Milvus homepage links to two specified blog posts
 
 ## Next Action
 
@@ -83,6 +83,7 @@ production workflows for one SHA, then require a zero-finding live rerun.
 | 260813-hsp | Improve Sealos Skills Hero top spacing below the shared header | 2026-08-13 | Pending |  | [260813-hsp-improve-sealos-skills-hero-top-spacing](./quick/260813-hsp-improve-sealos-skills-hero-top-spacing/) |
 | 260814 | Rename Header and Footer Sealos Skills labels to Agents | 2026-08-14 | Pending |  | [260814-rename-nav-footer-agents](./quick/260814-rename-nav-footer-agents/) |
 | 260816-m0b | Migrate current upstream main from npm to pnpm for shared Codex worktree dependencies | 2026-08-16 | 32919bc | Verified | [260816-m0b-migrate-current-upstream-main-from-npm-t](./quick/260816-m0b-migrate-current-upstream-main-from-npm-t/) |
+| 260901-kum | Add Milvus homepage links to two specified blog posts | 2026-09-01 | 6511728 |  | [260901-kum-add-milvus-homepage-links-to-two-specifi](./quick/260901-kum-add-milvus-homepage-links-to-two-specifi/) |
 
 ## Performance Metrics
 

--- a/content/blog/(app-deployment)/how-to-build-and-deploy-a-rag-pipeline-with-llama-3-and-milvus-on-sealos/index.en.md
+++ b/content/blog/(app-deployment)/how-to-build-and-deploy-a-rag-pipeline-with-llama-3-and-milvus-on-sealos/index.en.md
@@ -8,7 +8,7 @@ tags:
 authors: ["default"]
 ---
 
-If you’ve experimented with large language models (LLMs), you’ve likely encountered hallucinations and outdated answers. Retrieval-Augmented Generation (RAG) fixes that by grounding an LLM’s output in your own data. In this guide, you’ll learn how to build and deploy a production-ready RAG pipeline using Llama 3 for generation, Milvus for vector search, and Sealos for seamless cloud deployment. We’ll walk through architecture, deployment, code, and best practices—so you can go from zero to working system quickly and safely.
+If you’ve experimented with large language models (LLMs), you’ve likely encountered hallucinations and outdated answers. Retrieval-Augmented Generation (RAG) fixes that by grounding an LLM’s output in your own data. In this guide, you’ll learn how to build and deploy a production-ready RAG pipeline using Llama 3 for generation, [Milvus](https://milvus.io/) for vector search, and Sealos for seamless cloud deployment. We’ll walk through architecture, deployment, code, and best practices—so you can go from zero to working system quickly and safely.
 
 ## What You’ll Build
 

--- a/content/blog/(best-practices)/advanced-rag-pipelines-why-your-choice-of-vector-database-like-milvus-matters/index.en.md
+++ b/content/blog/(best-practices)/advanced-rag-pipelines-why-your-choice-of-vector-database-like-milvus-matters/index.en.md
@@ -15,7 +15,7 @@ Enter Retrieval-Augmented Generation (RAG). RAG is the ingenious technique that 
 
 But as developers move from simple prototypes to robust, production-grade applications, they quickly discover that a basic RAG setup is not enough. The real power lies in **Advanced RAG pipelines**, and at the heart of these sophisticated systems is a component that is often overlooked: the **vector database**.
 
-This article dives deep into the world of advanced RAG. We'll explore why the transition from simple to advanced RAG is necessary and demonstrate why your choice of vector database—like the open-source powerhouse, **Milvus**—is not just a technical detail, but a critical architectural decision that will define the performance, scalability, and intelligence of your AI application.
+This article dives deep into the world of advanced RAG. We'll explore why the transition from simple to advanced RAG is necessary and demonstrate why your choice of vector database—like the open-source powerhouse, [**Milvus**](https://milvus.io/)—is not just a technical detail, but a critical architectural decision that will define the performance, scalability, and intelligence of your AI application.
 
 ## From Simple RAG to Advanced Pipelines
 


### PR DESCRIPTION
## Summary

- Link the first body mention of Milvus in two RAG articles to https://milvus.io/
- Preserve the existing article wording and bold emphasis
- Record the completed quick task in project state

## Verification

- pnpm exec fumadocs-mdx
- Confirmed exactly one canonical Milvus link in each target article